### PR TITLE
Remove example endpoints and add backend scripts

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,15 +25,3 @@ app.include_router(auth.router, prefix="/auth", tags=["authentication"])
 @app.get("/")
 async def root():
     return {"message": "Welcome to StartupConnect API"}
-
-
-@app.get("/items/{item_id}")
-async def read_item(item_id: int, q: str | None = None):
-    if q:
-        return {"item_id": item_id, "q": q}
-    return {"item_id": item_id}
-
-
-@app.get("/users/{user_id}/items/{item_id}")
-async def read_user_item(user_id: int, item_id: str):
-    return {"user_id": user_id, "item_id": item_id}

--- a/backend/scripts/format.sh
+++ b/backend/scripts/format.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+set -x
+
+ruff check app scripts --fix
+ruff format app scripts

--- a/backend/scripts/lint.sh
+++ b/backend/scripts/lint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+mypy app
+ruff check app
+ruff format app --check

--- a/backend/scripts/prestart.sh
+++ b/backend/scripts/prestart.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+set -e
+set -x
+
+# Let the DB start
+python app/backend_pre_start.py
+
+# Run migrations
+alembic upgrade head
+
+# Create initial data in DB
+python app/initial_data.py

--- a/backend/scripts/test-start.sh
+++ b/backend/scripts/test-start.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+set -e
+set -x
+
+python app/tests_pre_start.py
+
+bash scripts/test.sh "$@"

--- a/backend/scripts/test.sh
+++ b/backend/scripts/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+coverage run --source=app -m pytest
+coverage report --show-missing
+coverage html --title "${@-coverage}"


### PR DESCRIPTION
### TL;DR

Removed example endpoints and added development scripts for the backend.

### What changed?

- Removed example endpoints from `main.py` (items and users/items endpoints)
- Created an empty `core` package in the backend
- Added several shell scripts for development workflows:
  - `format.sh`: Runs ruff to check and format code
  - `lint.sh`: Runs mypy and ruff for type checking and linting
  - `prestart.sh`: Prepares the database before starting the application
  - `test-start.sh`: Prepares the environment for testing
  - `test.sh`: Runs tests with coverage reporting

### How to test?

1. Run the scripts to verify they work correctly:
   ```bash
   cd backend
   bash scripts/lint.sh
   bash scripts/format.sh
   bash scripts/test.sh
   ```
2. Verify the API still works without the removed example endpoints

### Why make this change?

This change cleans up the codebase by removing example endpoints that aren't needed for production and adds essential development scripts that standardize code quality processes. The scripts will help maintain consistent code formatting, linting, and testing practices across the project, making it easier for developers to contribute while ensuring code quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added scripts for code formatting, linting, backend initialization, and testing to streamline development and deployment workflows.

- **Bug Fixes**
	- Removed two endpoints related to item and user-item retrieval from the backend API. Only the root endpoint remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->