### PR TITLE
other routers

### DIFF
--- a/backend/.cursor/mcp.json
+++ b/backend/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/backend/.cursor/rules/fastapi-python-cursor-rules.mdc
+++ b/backend/.cursor/rules/fastapi-python-cursor-rules.mdc
@@ -1,0 +1,66 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+You are an expert in Python, FastAPI, and scalable API development.
+  
+  Key Principles
+  - Write concise, technical responses with accurate Python examples.
+  - Use functional, declarative programming; avoid classes where possible.
+  - Prefer iteration and modularization over code duplication.
+  - Use descriptive variable names with auxiliary verbs (e.g., is_active, has_permission).
+  - Use lowercase with underscores for directories and files (e.g., routers/user_routes.py).
+  - Favor named exports for routes and utility functions.
+  - Use the Receive an Object, Return an Object (RORO) pattern.
+  
+  Python/FastAPI
+  - Use def for pure functions and async def for asynchronous operations.
+  - Use type hints for all function signatures. Prefer Pydantic models over raw dictionaries for input validation.
+  - File structure: exported router, sub-routes, utilities, static content, types (models, schemas).
+  - Use proper indentation for code blocks in conditional statements.
+  - For simple conditional statements, consider using one-line syntax when appropriate (e.g., if condition: do_something()).
+  - Avoid overly complex conditionals; extract complex conditions to named variables or functions for clarity.
+  
+  Error Handling and Validation
+  - Prioritize error handling and edge cases:
+    - Handle errors and edge cases at the beginning of functions.
+    - Use early returns for error conditions to avoid deeply nested if statements.
+    - Place the happy path last in the function for improved readability.
+    - Avoid unnecessary else statements; use the if-return pattern instead.
+    - Use guard clauses to handle preconditions and invalid states early.
+    - Implement proper error logging and user-friendly error messages.
+    - Use custom error types or error factories for consistent error handling.
+  
+  Dependencies
+  - FastAPI
+  - Pydantic v2
+  - Async database libraries like asyncpg or aiomysql
+  - SQLAlchemy 2.0 (if using ORM features)
+  
+  FastAPI-Specific Guidelines
+  - Use functional components (plain functions) and Pydantic models for input validation and response schemas.
+  - Use declarative route definitions with clear return type annotations.
+  - Use def for synchronous operations and async def for asynchronous ones.
+  - Minimize @app.on_event("startup") and @app.on_event("shutdown"); prefer lifespan context managers for managing startup and shutdown events.
+  - Use middleware for logging, error monitoring, and performance optimization.
+  - Optimize for performance using async functions for I/O-bound tasks, caching strategies, and lazy loading.
+  - Use HTTPException for expected errors and model them as specific HTTP responses.
+  - Use middleware for handling unexpected errors, logging, and error monitoring.
+  - Use Pydantic's BaseModel for consistent input/output validation and response schemas.
+  
+  Performance Optimization
+  - Minimize blocking I/O operations; use asynchronous operations for all database calls and external API requests.
+  - Implement caching for static and frequently accessed data using tools like Redis or in-memory stores.
+  - Optimize data serialization and deserialization with Pydantic.
+  - Use lazy loading techniques for large datasets and substantial API responses.
+  
+  Key Conventions
+  1. Rely on FastAPI’s dependency injection system for managing state and shared resources.
+  2. Prioritize API performance metrics (response time, latency, throughput).
+  3. Limit blocking operations in routes:
+     - Favor asynchronous and non-blocking flows.
+     - Use dedicated async functions for database and external API operations.
+     - Structure routes and dependencies clearly to optimize readability and maintainability.
+  
+  Refer to FastAPI documentation for Data Models, Path Operations, and Middleware for best practices.

--- a/backend/app/algo/startup-prediction.py
+++ b/backend/app/algo/startup-prediction.py
@@ -1,0 +1,1 @@
+## Investor Prediction Algorithm

--- a/backend/app/api/endpoints/investor.py
+++ b/backend/app/api/endpoints/investor.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/investor", tags=["Investor"])
+
+@router.get("/")
+async def create_investor():
+    return {"message": "Investor created"}
+
+@router.put("/update")
+async def update_investor():
+    return {"message": "Investor updated"}
+
+@router.delete("/delete")
+async def delete_investor():
+    return {"message": "Investor deleted"}
+
+@router.get("/:details")
+async def get_investor_details_by_id():
+    return {"message": "Investor details by ID"}

--- a/backend/app/api/endpoints/startups.py
+++ b/backend/app/api/endpoints/startups.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import List
+
+from app.api.deps import SessionDep
+from app.crud.startup import get_startups
+from app.models.startup import Startup
+
+router = APIRouter(prefix="/startups", tags=["startups"])
+
+
+@router.get("/", response_model=List[Startup])
+async def get_all_startups(session: SessionDep):
+    """Get all startups"""
+    startups = get_startups(db=session)
+    if not startups:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No startups found"
+        )
+    return startups
+
+
+@router.post("/create")
+async def create_startup():
+    return {"message": "Startup created"}
+
+
+@router.put("/update")
+async def update_startup():
+    return {"message": "Startup updated"}
+
+
+@router.delete("/delete")
+async def delete_startup():
+    return {"message": "Startup deleted"}
+
+
+@router.get("/:details")
+async def get_startup_details():
+    return {"message": "Startup details"}

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter,status
-from app.api.endpoints import users
+from app.api.endpoints import users,startups,investor
 
 api_router = APIRouter()
 
 api_router.get("/healthcheck", status_code=status.HTTP_200_OK, tags=["healthcheck"])(lambda: {"status": "ok"})
 api_router.include_router(users.router)
+api_router.include_router(startups.router)
+api_router.include_router(investor.router)

--- a/backend/app/crud/startup.py
+++ b/backend/app/crud/startup.py
@@ -1,15 +1,28 @@
-from typing import List, Optional
+from typing import Optional, Sequence
 
 from sqlmodel import Session, select
 
-from app.models.startup import Startup
-from app.schemas.startup import StartupCreate, StartupUpdate
+from app.models.startup import Startup, StartupCreate, StartupUpdate
 
-
+"""
+    Get a startup by id 
+    @param db: Session
+    @param startup_id: int
+    @return Optional[Startup]   
+"""
 def get_startup(db: Session, startup_id: int) -> Optional[Startup]:
     return db.get(Startup, startup_id)
 
-
+"""
+    Get all startups
+    @param db: Session
+    @param skip: int
+    @param limit: int
+    @param industry: Optional[str]
+    @param location: Optional[str]
+    @param funding_stage: Optional[str]
+    @return Sequence[Startup]
+"""
 def get_startups(
     db: Session,
     skip: int = 0,
@@ -17,7 +30,7 @@ def get_startups(
     industry: Optional[str] = None,
     location: Optional[str] = None,
     funding_stage: Optional[str] = None,
-) -> List[Startup]:
+) -> Sequence[Startup]:
     statement = select(Startup)
 
     if industry:
@@ -28,9 +41,16 @@ def get_startups(
         statement = statement.where(Startup.funding_stage == funding_stage)
 
     statement = statement.offset(skip).limit(limit)
-    return db.exec(statement).all()
+    results = db.exec(statement).all()
+    return results
 
 
+"""
+    Create a startup
+    @param db: Session
+    @param startup: StartupCreate
+    @return Startup
+"""
 def create_startup(db: Session, startup: StartupCreate) -> Startup:
     db_startup = Startup(**startup.model_dump())
     db.add(db_startup)
@@ -38,7 +58,13 @@ def create_startup(db: Session, startup: StartupCreate) -> Startup:
     db.refresh(db_startup)
     return db_startup
 
-
+"""
+    Update a startup
+    @param db: Session
+    @param startup_id: int
+    @param startup: StartupUpdate
+    @return Optional[Startup]
+"""
 def update_startup(
     db: Session, startup_id: int, startup: StartupUpdate
 ) -> Optional[Startup]:
@@ -55,7 +81,12 @@ def update_startup(
     db.refresh(db_startup)
     return db_startup
 
-
+"""
+    Delete a startup
+    @param db: Session
+    @param startup_id: int
+    @return bool
+"""
 def delete_startup(db: Session, startup_id: int) -> bool:
     db_startup = get_startup(db, startup_id)
     if not db_startup:
@@ -66,39 +97,91 @@ def delete_startup(db: Session, startup_id: int) -> bool:
     return True
 
 
+"""
+    Get a startup by founder id
+    @param db: Session
+    @param founder_id: int
+    @return Optional[Startup]
+"""
 def get_startup_by_founder(db: Session, founder_id: int) -> Optional[Startup]:
     statement = select(Startup).where(Startup.founder_id == founder_id)
-    return db.exec(statement).first()
+    result = db.exec(statement).first()
+    return result
 
-
-def get_startups_by_founder(db: Session, founder_id: int) -> List[Startup]:
+"""
+    Get all startups by founder id
+    @param db: Session
+    @param founder_id: int
+    @return Sequence[Startup]
+"""
+def get_startups_by_founder(db: Session, founder_id: int) -> Sequence[Startup]:
     statement = select(Startup).where(Startup.founder_id == founder_id)
-    return db.exec(statement).all()
+    results = db.exec(statement).all()
+    return results
 
 
-def get_startups_by_industry(db: Session, industry: str) -> List[Startup]:
+"""
+    Get all startups by industry
+    @param db: Session
+    @param industry: str
+    @return Sequence[Startup]
+"""
+def get_startups_by_industry(db: Session, industry: str) -> Sequence[Startup]:
     statement = select(Startup).where(Startup.industry == industry)
-    return db.exec(statement).all()
+    results = db.exec(statement).all()
+    return results
 
 
-def get_startups_by_location(db: Session, location: str) -> List[Startup]:
+"""
+    Get all startups by location
+    @param db: Session
+    @param location: str
+    @return Sequence[Startup]
+"""
+def get_startups_by_location(db: Session, location: str) -> Sequence[Startup]:
     statement = select(Startup).where(Startup.location == location)
-    return db.exec(statement).all()
+    results = db.exec(statement).all()
+    return results
 
-
-def get_startups_by_funding_stage(db: Session, funding_stage: str) -> List[Startup]:
+"""
+    Get all startups by funding stage
+    @param db: Session
+    @param funding_stage: str
+    @return Sequence[Startup]
+"""
+def get_startups_by_funding_stage(db: Session, funding_stage: str) -> Sequence[Startup]:
     statement = select(Startup).where(Startup.funding_stage == funding_stage)
-    return db.exec(statement).all()
+    results = db.exec(statement).all()
+    return results
 
-
-def get_startups_by_funding_amount(db: Session, funding_amount: float) -> List[Startup]:
-    return db.query(Startup).filter(Startup.funding_amount == funding_amount).all()
+""" 
+def get_startups_by_funding_amount(db: Session, funding_amount: float) -> Sequence[Startup]:
+    statement = select(Startup).where(
+        Startup.funding_goal >= funding_amount,
+        Startup.funding_goal <= funding_amount + 1000000,
+    )
+    results = db.exec(statement).all()
+    return results
 
 
 def get_startups_by_funding_amount_range(
     db: Session, min_funding: float, max_funding: float
-) -> List[Startup]:
+) -> Sequence[Startup]:
     statement = select(Startup).where(
         Startup.funding_goal >= min_funding, Startup.funding_goal <= max_funding
     )
-    return db.exec(statement).all()
+    results = db.exec(statement).all()
+    return results
+
+
+def get_startups_by_funding_goal_range(
+    db: Session, min_funding: float, max_funding: float
+) -> Sequence[Startup]:
+    statement = select(Startup).where(
+        Startup.funding_goal >= min_funding, Startup.funding_goal <= max_funding
+    )
+    results = db.exec(statement).all()
+    return results
+
+
+"""

--- a/backend/app/migrations/versions/773bda61d81a_users_investors_startups_migration.py
+++ b/backend/app/migrations/versions/773bda61d81a_users_investors_startups_migration.py
@@ -1,8 +1,8 @@
-"""users_startup_init_models
+"""users/investors & startups migration
 
-Revision ID: e1fb02146814
+Revision ID: 773bda61d81a
 Revises:
-Create Date: 2025-04-28 12:42:19.604909
+Create Date: 2025-05-03 19:24:11.896435
 
 """
 from typing import Sequence, Union
@@ -11,9 +11,8 @@ from alembic import op
 import sqlalchemy as sa
 import sqlmodel
 
-
 # revision identifiers, used by Alembic.
-revision: str = 'e1fb02146814'
+revision: str = '773bda61d81a'
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -38,12 +37,26 @@ def upgrade() -> None:
     sa.Column('description', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
     sa.Column('industry', sa.Enum('TECHNOLOGY', 'HEALTHCARE', 'FINANCE', 'EDUCATION', 'RETAIL', 'MANUFACTURING', 'OTHER', name='industry'), nullable=False),
     sa.Column('location', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-    sa.Column('funding_goal', sa.Float(), nullable=False),
-    sa.Column('funding_stage', sa.Enum('IDEA', 'MVP', 'EARLY_STAGE', 'GROWTH', 'SCALE', name='fundingstage'), nullable=False),
+    sa.Column('funding_stage', sa.Enum('IDEA', 'MVP', 'EARLY_STAGE', 'PRESEED', 'SEED', 'SERIES_A', 'SERIES_B', 'SERIES_C', 'IPO', 'MERGER_ACQUISITION', 'OTHER', name='fundingstage'), nullable=False),
+    sa.Column('funding_goal', sa.Float(), nullable=True),
+    sa.Column('founded_year', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('team_size', sa.Integer(), nullable=True),
     sa.Column('website', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('logo_url', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('pitch_deck_url', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('business_model', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('target_market', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('competitors', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('id', sa.Uuid(), nullable=False),
     sa.Column('founder_id', sa.Uuid(), nullable=False),
+    sa.Column('team_members', sa.JSON(), nullable=True),
+    sa.Column('funding', sa.JSON(), nullable=True),
+    sa.Column('metrics', sa.JSON(), nullable=True),
+    sa.Column('social_media', sa.JSON(), nullable=True),
+    sa.Column('contact', sa.JSON(), nullable=True),
+    sa.Column('traction', sa.JSON(), nullable=True),
+    sa.Column('use_of_funds', sa.JSON(), nullable=True),
+    sa.Column('timeline', sa.JSON(), nullable=True),
     sa.ForeignKeyConstraint(['founder_id'], ['user.id'], ),
     sa.PrimaryKeyConstraint('id')
     )

--- a/backend/app/models/startup.py
+++ b/backend/app/models/startup.py
@@ -1,7 +1,8 @@
 import enum
 import uuid
-from typing import Optional
+from typing import List, Optional, Dict, Any
 
+from sqlalchemy import Column, JSON
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -12,6 +13,25 @@ class Industry(str, enum.Enum):
     EDUCATION = "education"
     RETAIL = "retail"
     MANUFACTURING = "manufacturing"
+    REAL_ESTATE = "real_estate"
+    ENERGY = "energy"
+    TRANSPORTATION = "transportation"
+    MEDIA = "media"
+    ENTERTAINMENT = "entertainment"
+    FOOD_BEVERAGE = "food_beverage"
+    AGRICULTURE = "agriculture"
+    HOSPITALITY = "hospitality"
+    CONSTRUCTION = "construction"
+    TELECOMMUNICATIONS = "telecommunications"
+    BIOTECHNOLOGY = "biotechnology"
+    AEROSPACE = "aerospace"
+    AUTOMOTIVE = "automotive"
+    ECOMMERCE = "ecommerce"
+    GAMING = "gaming"
+    CYBERSECURITY = "cybersecurity"
+    FINTECH = "fintech"
+    HEALTHTECH = "healthtech"
+    EDTECH = "edtech"
     OTHER = "other"
 
 
@@ -19,8 +39,71 @@ class FundingStage(str, enum.Enum):
     IDEA = "idea"
     MVP = "mvp"
     EARLY_STAGE = "early_stage"
-    GROWTH = "growth"
-    SCALE = "scale"
+    PRESEED = "pre_seed"
+    SEED = "seed"
+    SERIES_A = "series_a"
+    SERIES_B = "series_b"
+    SERIES_C = "series_c"
+    IPO = "ipo"
+    MERGER_ACQUISITION = "merger_acquisition"
+    OTHER = "other"
+
+
+class TeamMember(SQLModel):
+    name: str
+    role: str
+    bio: Optional[str] = None
+
+
+class Funding(SQLModel):
+    total: Optional[float] = None
+    last_round: Optional[str] = None
+    investors: Optional[str] = None
+
+
+class Metrics(SQLModel):
+    revenue: Optional[str] = None
+    growth: Optional[str] = None
+    customers: Optional[int] = None
+
+
+class SocialMedia(SQLModel):
+    twitter: Optional[str] = None
+    linkedin: Optional[str] = None
+    facebook: Optional[str] = None
+    instagram: Optional[str] = None
+
+
+class Contact(SQLModel):
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    address: Optional[str] = None
+
+
+class Traction(SQLModel):
+    users: Optional[int] = None
+    revenue: Optional[float] = None
+    growth: Optional[float] = None
+    partnerships: Optional[str] = None
+
+
+class UseOfFunds(SQLModel):
+    product: Optional[float] = None
+    marketing: Optional[float] = None
+    operations: Optional[float] = None
+    team: Optional[float] = None
+    other: Optional[float] = None
+
+
+class TimelineEvent(SQLModel):
+    date: str
+    title: str
+    description: Optional[str] = None
+
+
+class Timeline(SQLModel):
+    past: List[TimelineEvent] = []
+    future: List[TimelineEvent] = []
 
 
 class StartupBase(SQLModel):
@@ -28,27 +111,58 @@ class StartupBase(SQLModel):
     description: str
     industry: Industry
     location: str
-    funding_goal: float
     funding_stage: FundingStage
+    funding_goal: Optional[float] = None
+    founded_year: Optional[str] = None
+    team_size: Optional[int] = None
     website: Optional[str] = None
+    logo_url: Optional[str] = None
     pitch_deck_url: Optional[str] = None
+    business_model: Optional[str] = None
+    target_market: Optional[str] = None
+    competitors: Optional[str] = None
 
 
 class Startup(StartupBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     founder_id: uuid.UUID = Field(foreign_key="user.id")
 
+    # JSON fields stored with SQLAlchemy JSON type
+    team_members: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    funding: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    metrics: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    social_media: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    contact: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    traction: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    use_of_funds: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    timeline: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+
     # Relationships
     founder: "User" = Relationship(back_populates="startups")  # type: ignore  # noqa: F821
 
 
 class StartupCreate(StartupBase):
-    pass
+    team_members: Optional[Dict[str, Any]] = None
+    funding: Optional[Dict[str, Any]] = None
+    metrics: Optional[Dict[str, Any]] = None
+    social_media: Optional[Dict[str, Any]] = None
+    contact: Optional[Dict[str, Any]] = None
+    traction: Optional[Dict[str, Any]] = None
+    use_of_funds: Optional[Dict[str, Any]] = None
+    timeline: Optional[Dict[str, Any]] = None
 
 
 class StartupRead(StartupBase):
     id: uuid.UUID
     founder_id: uuid.UUID
+    team_members: Optional[Dict[str, Any]] = None
+    funding: Optional[Dict[str, Any]] = None
+    metrics: Optional[Dict[str, Any]] = None
+    social_media: Optional[Dict[str, Any]] = None
+    contact: Optional[Dict[str, Any]] = None
+    traction: Optional[Dict[str, Any]] = None
+    use_of_funds: Optional[Dict[str, Any]] = None
+    timeline: Optional[Dict[str, Any]] = None
 
 
 class StartupUpdate(SQLModel):
@@ -58,5 +172,19 @@ class StartupUpdate(SQLModel):
     location: Optional[str] = None
     funding_goal: Optional[float] = None
     funding_stage: Optional[FundingStage] = None
+    founded_year: Optional[str] = None
+    team_size: Optional[int] = None
     website: Optional[str] = None
+    logo_url: Optional[str] = None
     pitch_deck_url: Optional[str] = None
+    business_model: Optional[str] = None
+    target_market: Optional[str] = None
+    competitors: Optional[str] = None
+    team_members: Optional[Dict[str, Any]] = None
+    funding: Optional[Dict[str, Any]] = None
+    metrics: Optional[Dict[str, Any]] = None
+    social_media: Optional[Dict[str, Any]] = None
+    contact: Optional[Dict[str, Any]] = None
+    traction: Optional[Dict[str, Any]] = None
+    use_of_funds: Optional[Dict[str, Any]] = None
+    timeline: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
### TL;DR

Added startup and investor API endpoints with enhanced startup model schema and CRUD operations.

### What changed?

- Created new API endpoints for startups and investors with basic CRUD operations
- Enhanced the startup model with additional fields:
  - Added more industry options (fintech, healthtech, etc.)
  - Expanded funding stages (pre-seed, seed, series A/B/C, etc.)
  - Added JSON fields for team members, metrics, social media, etc.
- Updated the database migration script to support the enhanced startup model
- Improved CRUD operations in `startup.py` with better documentation and return types
- Added FastAPI Python development rules for code consistency
- Created a placeholder for startup prediction algorithm

### How to test?

1. Run database migrations to apply the updated schema
2. Test the new API endpoints:
   - GET `/startups/` to retrieve all startups
   - POST `/startups/create` to create a new startup
   - PUT `/startups/update` to update a startup
   - DELETE `/startups/delete` to delete a startup
   - GET `/investor/` and other investor endpoints

### Why make this change?

This change enhances the platform's ability to manage detailed startup information and investor relationships. The expanded model allows for storing comprehensive startup data including team composition, funding details, metrics, and social media presence. The new API endpoints provide the necessary interfaces for both startups and investors to interact with the platform.