### PR TITLE
founder startups

### DIFF
--- a/frontend-sv/.cursor/rules/svelte5-sveltekit-development-guide.mdc
+++ b/frontend-sv/.cursor/rules/svelte5-sveltekit-development-guide.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: 
+globs: 
 alwaysApply: true
 ---
 You are an expert in Svelte 5, SvelteKit, TypeScript, and modern web development.
@@ -141,7 +141,7 @@ State Management
   import { counter } from './counter.svelte.ts';
   </script>
 
-  <button on:click={() => counter.increment()}>
+  <button onclick={() => counter.increment()}>
     Count: {counter.count}
   </button>
   ```

--- a/frontend-sv/src/lib/components/LoginForm.svelte
+++ b/frontend-sv/src/lib/components/LoginForm.svelte
@@ -11,7 +11,6 @@
     import { cn } from "@/utils";
     import { zodClient } from "sveltekit-superforms/adapters";
     import LoaderCircle from "@lucide/svelte/icons/loader-circle";
-    import AlertCircle from "@lucide/svelte/icons/alert-circle";
 
     let { data }: { data: { form: SuperValidated<Infer<LoginSchema>> } } =
         $props();

--- a/frontend-sv/src/lib/components/NewStartupForm.svelte
+++ b/frontend-sv/src/lib/components/NewStartupForm.svelte
@@ -1,0 +1,1483 @@
+<script lang="ts">
+    import FileUpload from "$lib/components/file-upload.svelte";
+    import { Button } from "$lib/components/ui/button";
+    import {
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
+    } from "$lib/components/ui/card";
+    import * as Form from "$lib/components/ui/form";
+    import { Input } from "$lib/components/ui/input";
+    import {
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+    } from "$lib/components/ui/select";
+    import { Textarea } from "$lib/components/ui/textarea";
+    import {
+        type StartupSchema,
+        startupSchema,
+    } from "@/schemas/startup-schema";
+    import { LoaderCircle } from "@lucide/svelte";
+    import { toast } from "svelte-sonner";
+    import {
+        type Infer,
+        superForm,
+        type SuperValidated,
+    } from "sveltekit-superforms";
+    import { zodClient } from "sveltekit-superforms/adapters";
+
+    let { data }: { data: { form: SuperValidated<Infer<StartupSchema>> } } =
+        $props();
+
+    // Use superForm to manage the form state
+    const form = superForm(data.form, {
+        dataType: "json",
+        validators: zodClient(startupSchema),
+        onUpdate({ form }) {
+            if (form.valid) {
+                toast.success("Startup profile saved");
+            }
+        },
+        onError(result) {
+            toast.error("Failed to save startup profile", {
+                description: "Please check the form for errors",
+            });
+        },
+    });
+
+    const {
+        form: formData,
+        errors,
+        enhance,
+        delayed,
+        message,
+        submitting,
+    } = form;
+
+    // State with Svelte 5 runes
+    let showPreview = $state(true);
+    let showTeamSection = $state(false);
+
+    // File handling with runes
+    let pitchDeckFile = $state<File | null>(null);
+    let logoFile = $state<File | null>(null);
+    let logoPreview = $state<string | null>(null);
+    let productScreenshots = $state<File[]>([]);
+    let demoVideo = $state<File | null>(null);
+    let screenshotPreviews = $state<string[]>([]);
+
+    // Handlers for file uploads
+    function handleFileUpload(event: { detail: { files: File[] } }) {
+        if (event.detail.files.length > 0) {
+            pitchDeckFile = event.detail.files[0];
+        }
+    }
+
+    function handleFileRemove() {
+        pitchDeckFile = null;
+    }
+
+    function handleLogoUpload(event: { detail: { files: File[] } }) {
+        if (event.detail.files.length > 0) {
+            logoFile = event.detail.files[0];
+            logoPreview = URL.createObjectURL(event.detail.files[0]);
+        }
+    }
+
+    function handleLogoRemove() {
+        logoFile = null;
+        if (logoPreview) {
+            URL.revokeObjectURL(logoPreview);
+            logoPreview = null;
+        }
+    }
+
+    function handleScreenshotUpload(event: { detail: { files: File[] } }) {
+        productScreenshots = event.detail.files;
+        screenshotPreviews = event.detail.files.map((file) =>
+            URL.createObjectURL(file),
+        );
+    }
+
+    function handleScreenshotRemove(index: number) {
+        URL.revokeObjectURL(screenshotPreviews[index]);
+        productScreenshots = productScreenshots.filter((_, i) => i !== index);
+        screenshotPreviews = screenshotPreviews.filter((_, i) => i !== index);
+    }
+
+    function handleDemoVideoUpload(event: { detail: { files: File[] } }) {
+        if (event.detail.files.length > 0) {
+            demoVideo = event.detail.files[0];
+        }
+    }
+
+    function handleDemoVideoRemove() {
+        demoVideo = null;
+    }
+
+    // Team members
+    function addTeamMember() {
+        const currentTeamMembers = $formData.teamMembers || [];
+        $formData.teamMembers = [
+            ...currentTeamMembers,
+            {
+                name: "",
+                role: "",
+                bio: "",
+                linkedin: "",
+            },
+        ];
+    }
+
+    function removeTeamMember(index: number) {
+        const currentTeamMembers = $formData.teamMembers || [];
+        $formData.teamMembers = currentTeamMembers.filter(
+            (_, i) => i !== index,
+        );
+    }
+
+    // Timeline milestones
+    function addPastMilestone() {
+        const timeline = $formData.timeline || { past: [], future: [] };
+        const currentPast = timeline.past || [];
+
+        $formData.timeline = {
+            ...timeline,
+            past: [
+                ...currentPast,
+                {
+                    date: "",
+                    title: "",
+                    description: "",
+                    type: "achievement" as const,
+                },
+            ],
+        };
+    }
+
+    function removePastMilestone(index: number) {
+        if (!$formData.timeline?.past) return;
+
+        $formData.timeline = {
+            ...$formData.timeline,
+            past: $formData.timeline.past.filter((_, i) => i !== index),
+        };
+    }
+
+    function addFutureMilestone() {
+        const timeline = $formData.timeline || { past: [], future: [] };
+        const currentFuture = timeline.future || [];
+
+        $formData.timeline = {
+            ...timeline,
+            future: [
+                ...currentFuture,
+                {
+                    date: "",
+                    title: "",
+                    description: "",
+                    type: "launch" as const,
+                },
+            ],
+        };
+    }
+
+    function removeFutureMilestone(index: number) {
+        if (!$formData.timeline?.future) return;
+
+        $formData.timeline = {
+            ...$formData.timeline,
+            future: $formData.timeline.future.filter((_, i) => i !== index),
+        };
+    }
+
+    // Toggle functions
+    function togglePreview() {
+        showPreview = !showPreview;
+    }
+
+    function toggleTeamSection() {
+        showTeamSection = !showTeamSection;
+    }
+</script>
+
+<form method="POST" use:enhance class="space-y-8">
+    <!-- Basic Information -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Basic Information</CardTitle>
+            <CardDescription>Tell us about your startup</CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <!-- Logo Upload -->
+            <!-- <div>
+                <Form.Label>Startup Logo</Form.Label>
+                <div class="flex items-start gap-4">
+                    <div class="flex-1">
+                        <FileUpload
+                            accept="image/*"
+                            maxSize={2}
+                            multiple={false}
+                            onupload={handleLogoUpload}
+                            onremove={handleLogoRemove}
+                        />
+                        <p class="text-sm text-muted-foreground mt-2">
+                            Upload your startup logo (max 2MB, recommended size:
+                  nt           400x400px)
+                        </p>
+                    </div>
+                </div>
+            </div> -->
+
+            <Form.Field {form} name="name">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Startup Name</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="Enter your startup name"
+                            bind:value={$formData.name}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.name}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.name}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="description">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Description</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe your startup"
+                            class="min-h-[100px]"
+                            bind:value={$formData.description}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.description}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.description}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <div class="grid grid-cols-2 gap-4">
+                <Form.Field {form} name="industry">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Industry</Form.Label>
+                            <Select
+                                type="single"
+                                bind:value={$formData.industry}
+                                {...props}
+                            >
+                                <SelectTrigger>
+                                    <div class="placeholder">
+                                        Select industry
+                                    </div>
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="Technology"
+                                        >Technology</SelectItem
+                                    >
+                                    <SelectItem value="Healthcare"
+                                        >Healthcare</SelectItem
+                                    >
+                                    <SelectItem value="Fintech"
+                                        >Fintech</SelectItem
+                                    >
+                                    <SelectItem value="Clean Energy"
+                                        >Clean Energy</SelectItem
+                                    >
+                                    <SelectItem value="E-commerce"
+                                        >E-commerce</SelectItem
+                                    >
+                                </SelectContent>
+                            </Select>
+                        {/snippet}
+                    </Form.Control>
+                    {#if $errors.industry}
+                        <Form.FieldErrors class="text-destructive text-sm">
+                            {$errors.industry}
+                        </Form.FieldErrors>
+                    {/if}
+                </Form.Field>
+
+                <Form.Field {form} name="location">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Location</Form.Label>
+                            <Input
+                                {...props}
+                                placeholder="City, Country"
+                                bind:value={$formData.location}
+                            />
+                        {/snippet}
+                    </Form.Control>
+                    {#if $errors.location}
+                        <Form.FieldErrors class="text-destructive text-sm">
+                            {$errors.location}
+                        </Form.FieldErrors>
+                    {/if}
+                </Form.Field>
+            </div>
+        </CardContent>
+    </Card>
+
+    <!-- Company Details -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Company Details</CardTitle>
+            <CardDescription
+                >Additional information about your company</CardDescription
+            >
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <div class="grid grid-cols-2 gap-4">
+                <Form.Field {form} name="foundedYear">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Founded Year</Form.Label>
+                            <Input
+                                {...props}
+                                type="number"
+                                placeholder="YYYY"
+                                bind:value={$formData.foundedYear}
+                            />
+                        {/snippet}
+                    </Form.Control>
+                    {#if $errors.foundedYear}
+                        <Form.FieldErrors class="text-destructive text-sm">
+                            {$errors.foundedYear}
+                        </Form.FieldErrors>
+                    {/if}
+                </Form.Field>
+
+                <Form.Field {form} name="teamSize">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Team Size</Form.Label>
+                            <Input
+                                {...props}
+                                type="number"
+                                placeholder="Number of employees"
+                                bind:value={$formData.teamSize}
+                            />
+                        {/snippet}
+                    </Form.Control>
+                    {#if $errors.teamSize}
+                        <Form.FieldErrors class="text-destructive text-sm">
+                            {$errors.teamSize}
+                        </Form.FieldErrors>
+                    {/if}
+                </Form.Field>
+            </div>
+
+            <Form.Field {form} name="website">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Website</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="https://your-startup.com"
+                            bind:value={$formData.website}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.website}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.website}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Funding Information -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Funding Information</CardTitle>
+            <CardDescription>Details about your funding status</CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <Form.Field {form} name="fundingStage">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Funding Stage</Form.Label>
+                        <Select
+                            type="single"
+                            bind:value={$formData.fundingStage}
+                            {...props}
+                        >
+                            <SelectTrigger>
+                                <div class="placeholder">
+                                    Select funding stage
+                                </div>
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="Pre-seed"
+                                    >Pre-seed</SelectItem
+                                >
+                                <SelectItem value="Seed">Seed</SelectItem>
+                                <SelectItem value="Series A"
+                                    >Series A</SelectItem
+                                >
+                                <SelectItem value="Series B"
+                                    >Series B</SelectItem
+                                >
+                                <SelectItem value="Series C+"
+                                    >Series C+</SelectItem
+                                >
+                            </SelectContent>
+                        </Select>
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.fundingStage}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.fundingStage}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <div class="grid grid-cols-2 gap-4">
+                <Form.Field {form} name="funding.total">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Total Funding</Form.Label>
+                            <Input
+                                {...props}
+                                placeholder="e.g., $1M"
+                                bind:value={$formData.funding.total}
+                            />
+                        {/snippet}
+                    </Form.Control>
+                    <!-- {#if $errors["funding.total"]} -->
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        <!-- {$errors["funding.total"]} -->
+                    </Form.FieldErrors>
+                    <!-- {/if} -->
+                </Form.Field>
+
+                <Form.Field {form} name="funding.lastRound">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Last Round</Form.Label>
+                            <Input
+                                {...props}
+                                placeholder="e.g., Series A"
+                                bind:value={$formData.funding.lastRound}
+                            />
+                        {/snippet}
+                    </Form.Control>
+                    <!-- {#if $errors["funding.lastRound"]} -->
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        <!-- {$errors["funding.lastRound"]} -->
+                    </Form.FieldErrors>
+                    <!-- {/if} -->
+                </Form.Field>
+            </div>
+
+            <Form.Field {form} name="funding.investors">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Investors</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="List your investors (comma-separated)"
+                            bind:value={$formData.funding.investors}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.funding?.investors}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.funding?.investors}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Key Metrics -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Key Metrics</CardTitle>
+            <CardDescription>Your startup's performance metrics</CardDescription
+            >
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <div class="grid grid-cols-2 gap-4">
+                <Form.Field {form} name="metrics.revenue">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Revenue</Form.Label>
+                            <Input
+                                {...props}
+                                placeholder="e.g., $500K ARR"
+                                bind:value={$formData.metrics.revenue}
+                            />
+                        {/snippet}
+                    </Form.Control>
+                    {#if $errors.metrics?.revenue}
+                        <Form.FieldErrors class="text-destructive text-sm">
+                            {$errors.metrics?.revenue}
+                        </Form.FieldErrors>
+                    {/if}
+                </Form.Field>
+
+                <Form.Field {form} name="metrics.growth">
+                    <Form.Control>
+                        {#snippet children({ props })}
+                            <Form.Label>Growth Rate</Form.Label>
+                            <Input
+                                {...props}
+                                placeholder="e.g., 200% YoY"
+                                bind:value={$formData.metrics.growth}
+                            />
+                        {/snippet}
+                    </Form.Control>
+                    {#if $errors.metrics?.growth}
+                        <Form.FieldErrors class="text-destructive text-sm">
+                            {$errors.metrics?.growth}
+                        </Form.FieldErrors>
+                    {/if}
+                </Form.Field>
+            </div>
+
+            <Form.Field {form} name="metrics.customers">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Number of Customers</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="e.g., 50+ Enterprise Clients"
+                            bind:value={$formData.metrics.customers}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.metrics?.customers}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.metrics?.customers}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Team Section -->
+    <Card>
+        <CardHeader>
+            <div class="flex items-center justify-between">
+                <div>
+                    <CardTitle>Team Members</CardTitle>
+                    <CardDescription
+                        >Add information about your team</CardDescription
+                    >
+                </div>
+                <Button
+                    variant="outline"
+                    type="button"
+                    onclick={() => toggleTeamSection()}
+                >
+                    {showTeamSection
+                        ? "Hide Team Section"
+                        : "Show Team Section"}
+                </Button>
+            </div>
+        </CardHeader>
+        {#if showTeamSection}
+            <CardContent class="space-y-4">
+                {#if $formData.teamMembers && $formData.teamMembers.length > 0}
+                    {#each $formData.teamMembers as member, index}
+                        <div class="p-4 border rounded-lg space-y-4">
+                            <div class="flex justify-between items-center">
+                                <h3 class="font-medium">
+                                    Team Member {index + 1}
+                                </h3>
+                                <Button
+                                    variant="ghost"
+                                    type="button"
+                                    onclick={() => removeTeamMember(index)}
+                                    class="text-destructive"
+                                >
+                                    Remove
+                                </Button>
+                            </div>
+                            <div class="grid grid-cols-2 gap-4">
+                                <Form.Field
+                                    {form}
+                                    name={`teamMembers[${index}].name`}
+                                >
+                                    <Form.Control>
+                                        {#snippet children({ props })}
+                                            <Form.Label>Name</Form.Label>
+                                            <Input
+                                                {...props}
+                                                placeholder="Full name"
+                                                bind:value={member.name}
+                                            />
+                                        {/snippet}
+                                    </Form.Control>
+                                    {#if $errors.teamMembers?.[index]?.name}
+                                        <Form.FieldErrors
+                                            class="text-destructive text-sm"
+                                        >
+                                            {$errors.teamMembers[index].name}
+                                        </Form.FieldErrors>
+                                    {/if}
+                                </Form.Field>
+                                <Form.Field
+                                    {form}
+                                    name={`teamMembers[${index}].role`}
+                                >
+                                    <Form.Control>
+                                        {#snippet children({ props })}
+                                            <Form.Label>Role</Form.Label>
+                                            <Input
+                                                {...props}
+                                                placeholder="e.g., CEO, CTO"
+                                                bind:value={member.role}
+                                            />
+                                        {/snippet}
+                                    </Form.Control>
+                                    {#if $errors.teamMembers?.[index]?.role}
+                                        <Form.FieldErrors
+                                            class="text-destructive text-sm"
+                                        >
+                                            {$errors.teamMembers[index].role}
+                                        </Form.FieldErrors>
+                                    {/if}
+                                </Form.Field>
+                            </div>
+                            <Form.Field
+                                {form}
+                                name={`teamMembers[${index}].bio`}
+                            >
+                                <Form.Control>
+                                    {#snippet children({ props })}
+                                        <Form.Label>Bio</Form.Label>
+                                        <Textarea
+                                            {...props}
+                                            placeholder="Brief description of experience and expertise"
+                                            bind:value={member.bio}
+                                        />
+                                    {/snippet}
+                                </Form.Control>
+                                {#if $errors.teamMembers?.[index]?.bio}
+                                    <Form.FieldErrors
+                                        class="text-destructive text-sm"
+                                    >
+                                        {$errors.teamMembers[index].bio}
+                                    </Form.FieldErrors>
+                                {/if}
+                            </Form.Field>
+                            <Form.Field
+                                {form}
+                                name={`teamMembers[${index}].linkedin`}
+                            >
+                                <Form.Control>
+                                    {#snippet children({ props })}
+                                        <Form.Label
+                                            >LinkedIn Profile (Optional)</Form.Label
+                                        >
+                                        <Input
+                                            {...props}
+                                            placeholder="https://linkedin.com/in/..."
+                                            bind:value={member.linkedin}
+                                        />
+                                    {/snippet}
+                                </Form.Control>
+                                {#if $errors.teamMembers?.[index]?.linkedin}
+                                    <Form.FieldErrors
+                                        class="text-destructive text-sm"
+                                    >
+                                        {$errors.teamMembers[index].linkedin}
+                                    </Form.FieldErrors>
+                                {/if}
+                            </Form.Field>
+                        </div>
+                    {/each}
+                {/if}
+                <Button
+                    type="button"
+                    variant="outline"
+                    onclick={() => addTeamMember()}
+                    class="w-full"
+                >
+                    Add Team Member
+                </Button>
+            </CardContent>
+        {/if}
+    </Card>
+
+    <!-- Pitch Deck Upload -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Pitch Deck</CardTitle>
+            <CardDescription
+                >Upload your startup's pitch deck (PDF, PPT, or PPTX)</CardDescription
+            >
+        </CardHeader>
+        <CardContent>
+            <FileUpload
+                accept=".pdf,.ppt,.pptx"
+                maxSize={10}
+                multiple={false}
+                on:upload={handleFileUpload}
+                on:remove={handleFileRemove}
+            />
+        </CardContent>
+    </Card>
+
+    <!-- Social Media Links -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Social Media</CardTitle>
+            <CardDescription
+                >Add your startup's social media profiles</CardDescription
+            >
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <Form.Field {form} name="socialMedia.twitter">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Twitter</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="https://twitter.com/yourstartup"
+                            value={$formData.socialMedia?.twitter}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.socialMedia?.twitter}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.socialMedia?.twitter}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="socialMedia.linkedin">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>LinkedIn</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="https://linkedin.com/company/yourstartup"
+                            value={$formData.socialMedia?.linkedin}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.socialMedia?.linkedin}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.socialMedia?.linkedin}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="socialMedia.facebook">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Facebook</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="https://facebook.com/yourstartup"
+                            value={$formData.socialMedia?.facebook}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.socialMedia?.facebook}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.socialMedia?.facebook}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="socialMedia.instagram">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Instagram</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="https://instagram.com/yourstartup"
+                            value={$formData.socialMedia?.instagram}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.socialMedia?.instagram}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.socialMedia?.instagram}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Contact Information -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Contact Information</CardTitle>
+            <CardDescription>How investors can reach you</CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <Form.Field {form} name="contact.email">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Email</Form.Label>
+                        <Input
+                            {...props}
+                            type="email"
+                            placeholder="contact@yourstartup.com"
+                            bind:value={$formData.contact.email}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.contact?.email}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.contact?.email}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="contact.phone">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Phone (Optional)</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="+1 (555) 123-4567"
+                            bind:value={$formData.contact.phone}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.contact?.phone}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.contact?.phone}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="contact.address">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Address (Optional)</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="123 Startup St, Tech City, 12345"
+                            bind:value={$formData.contact.address}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.contact?.address}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.contact?.address}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Business Model -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Business Model</CardTitle>
+            <CardDescription
+                >Explain how your startup makes or will make money</CardDescription
+            >
+        </CardHeader>
+        <CardContent>
+            <Form.Field {form} name="businessModel">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Business Model</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe your revenue streams, pricing model, and business strategy"
+                            class="min-h-[150px]"
+                            bind:value={$formData.businessModel}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.businessModel}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.businessModel}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Target Market -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Target Market</CardTitle>
+            <CardDescription
+                >Define your ideal customers and market opportunity</CardDescription
+            >
+        </CardHeader>
+        <CardContent>
+            <Form.Field {form} name="targetMarket">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Target Market</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe your target audience, market size, and growth potential"
+                            class="min-h-[150px]"
+                            bind:value={$formData.targetMarket}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.targetMarket}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.targetMarket}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Competitors -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Competitors</CardTitle>
+            <CardDescription
+                >Identify your main competitors and your competitive advantage</CardDescription
+            >
+        </CardHeader>
+        <CardContent>
+            <Form.Field {form} name="competitors">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Competitors</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="List your main competitors and explain what sets you apart"
+                            class="min-h-[150px]"
+                            bind:value={$formData.competitors}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.competitors}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.competitors}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Traction -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Traction</CardTitle>
+            <CardDescription
+                >Share your startup's progress and milestones (Optional)</CardDescription
+            >
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <Form.Field {form} name="traction.users">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Users/Customers (Optional)</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="e.g., 10,000 active users"
+                            value={$formData.traction?.users}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.traction?.users}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.traction?.users}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="traction.revenue">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Revenue Traction (Optional)</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="e.g., $50K MRR with 15% MoM growth"
+                            value={$formData.traction?.revenue}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.traction?.revenue}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.traction?.revenue}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="traction.growth">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Growth Metrics (Optional)</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="e.g., 30% month-over-month user growth"
+                            value={$formData.traction?.growth}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.traction?.growth}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.traction?.growth}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="traction.partnerships">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Partnerships (Optional)</Form.Label>
+                        <Input
+                            {...props}
+                            placeholder="e.g., Strategic partnership with Amazon, Microsoft"
+                            value={$formData.traction?.partnerships}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.traction?.partnerships}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.traction?.partnerships}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Use of Funds -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Use of Funds</CardTitle>
+            <CardDescription
+                >Explain how you plan to use the investment</CardDescription
+            >
+        </CardHeader>
+        <CardContent class="space-y-4">
+            <Form.Field {form} name="useOfFunds.product">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Product Development</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe how funds will be used for product development"
+                            value={$formData.useOfFunds?.product}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.useOfFunds?.product}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.useOfFunds?.product}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="useOfFunds.marketing">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Marketing & Sales</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe your marketing and sales plans"
+                            value={$formData.useOfFunds?.marketing}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.useOfFunds?.marketing}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.useOfFunds?.marketing}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="useOfFunds.operations">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Operations</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe operational expenses and infrastructure plans"
+                            value={$formData.useOfFunds?.operations}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.useOfFunds?.operations}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.useOfFunds?.operations}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="useOfFunds.team">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Team Expansion</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe hiring plans and team growth strategy"
+                            value={$formData.useOfFunds?.team}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.useOfFunds?.team}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.useOfFunds?.team}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+
+            <Form.Field {form} name="useOfFunds.other">
+                <Form.Control>
+                    {#snippet children({ props })}
+                        <Form.Label>Other (Optional)</Form.Label>
+                        <Textarea
+                            {...props}
+                            placeholder="Describe any other use of funds not covered above"
+                            value={$formData.useOfFunds?.other}
+                        />
+                    {/snippet}
+                </Form.Control>
+                {#if $errors.useOfFunds?.other}
+                    <Form.FieldErrors class="text-destructive text-sm">
+                        {$errors.useOfFunds?.other}
+                    </Form.FieldErrors>
+                {/if}
+            </Form.Field>
+        </CardContent>
+    </Card>
+
+    <!-- Timeline -->
+    <Card>
+        <CardHeader>
+            <CardTitle>Timeline</CardTitle>
+            <CardDescription>
+                Share your past achievements and future plans
+            </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-6">
+            <!-- Past Milestones -->
+            <div>
+                <h3 class="text-lg font-medium mb-4">Past Milestones</h3>
+
+                {#if $formData.timeline?.past && $formData.timeline.past.length > 0}
+                    {#each $formData.timeline.past as _, index}
+                        <div class="p-4 border rounded-lg space-y-4 mb-4">
+                            <div class="flex justify-between items-center">
+                                <h4 class="font-medium">
+                                    Milestone {index + 1}
+                                </h4>
+                                <Button
+                                    variant="ghost"
+                                    type="button"
+                                    onclick={() => removePastMilestone(index)}
+                                    class="text-destructive"
+                                >
+                                    Remove
+                                </Button>
+                            </div>
+
+                            <div class="grid grid-cols-2 gap-4">
+                                <Form.Field
+                                    {form}
+                                    name={`timeline.past[${index}].date`}
+                                >
+                                    <Form.Control>
+                                        {#snippet children({ props })}
+                                            <Form.Label>Date</Form.Label>
+                                            <Input
+                                                {...props}
+                                                placeholder="e.g., January 2023"
+                                            />
+                                        {/snippet}
+                                    </Form.Control>
+                                    <!-- {#if $errors.timeline?.past?.[index]?.date} -->
+                                    <Form.FieldErrors
+                                        class="text-destructive text-sm"
+                                    >
+                                        <!-- {$errors.timeline.past[index].date} -->
+                                    </Form.FieldErrors>
+                                    <!-- {/if} -->
+                                </Form.Field>
+
+                                <Form.Field
+                                    {form}
+                                    name={`timeline.past[${index}].type`}
+                                >
+                                    <Form.Control>
+                                        {#snippet children({ props })}
+                                            <Form.Label>Type</Form.Label>
+                                            <Select type="single" {...props}>
+                                                <SelectTrigger>
+                                                    <div class="placeholder">
+                                                        Select milestone type
+                                                    </div>
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem
+                                                        value="achievement"
+                                                        >Achievement</SelectItem
+                                                    >
+                                                    <SelectItem value="funding"
+                                                        >Funding</SelectItem
+                                                    >
+                                                    <SelectItem
+                                                        value="partnership"
+                                                        >Partnership</SelectItem
+                                                    >
+                                                    <SelectItem value="product"
+                                                        >Product</SelectItem
+                                                    >
+                                                    <SelectItem value="other"
+                                                        >Other</SelectItem
+                                                    >
+                                                </SelectContent>
+                                            </Select>
+                                        {/snippet}
+                                    </Form.Control>
+                                    <!-- {#if $errors.timeline?.past?.[index]?.type} -->
+                                    <Form.FieldErrors
+                                        class="text-destructive text-sm"
+                                    >
+                                        <!-- {$errors.timeline.past[index].type} -->
+                                    </Form.FieldErrors>
+                                    <!-- {/if} -->
+                                </Form.Field>
+                            </div>
+
+                            <Form.Field
+                                {form}
+                                name={`timeline.past[${index}].title`}
+                            >
+                                <Form.Control>
+                                    {#snippet children({ props })}
+                                        <Form.Label>Title</Form.Label>
+                                        <Input
+                                            {...props}
+                                            placeholder="e.g., Secured seed funding"
+                                        />
+                                    {/snippet}
+                                </Form.Control>
+                                <!-- {#if $errors.timeline?.past?.[index]?.title} -->
+                                <Form.FieldErrors
+                                    class="text-destructive text-sm"
+                                >
+                                    <!-- {$errors.timeline.past[index].title} -->
+                                </Form.FieldErrors>
+                                <!-- {/if} -->
+                            </Form.Field>
+
+                            <Form.Field
+                                {form}
+                                name={`timeline.past[${index}].description`}
+                            >
+                                <Form.Control>
+                                    {#snippet children({ props })}
+                                        <Form.Label>Description</Form.Label>
+                                        <Textarea
+                                            {...props}
+                                            placeholder="Describe the milestone"
+                                        />
+                                    {/snippet}
+                                </Form.Control>
+                                <!-- {#if $errors.timeline?.past?.[index]?.description} -->
+                                <Form.FieldErrors
+                                    class="text-destructive text-sm"
+                                >
+                                    <!-- {$errors.timeline.past[index]
+                                            .description} -->
+                                </Form.FieldErrors>
+                                <!-- {/if} -->
+                            </Form.Field>
+                        </div>
+                    {/each}
+                {/if}
+
+                <Button
+                    type="button"
+                    variant="outline"
+                    onclick={() => addPastMilestone()}
+                    class="w-full"
+                >
+                    Add Past Milestone
+                </Button>
+            </div>
+
+            <!-- Future Milestones -->
+            <div>
+                <h3 class="text-lg font-medium mb-4">Future Milestones</h3>
+
+                {#if $formData.timeline?.future && $formData.timeline.future.length > 0}
+                    {#each $formData.timeline.future as _, index}
+                        <div class="p-4 border rounded-lg space-y-4 mb-4">
+                            <div class="flex justify-between items-center">
+                                <h4 class="font-medium">
+                                    Milestone {index + 1}
+                                </h4>
+                                <Button
+                                    variant="ghost"
+                                    type="button"
+                                    onclick={() => removeFutureMilestone(index)}
+                                    class="text-destructive"
+                                >
+                                    Remove
+                                </Button>
+                            </div>
+
+                            <div class="grid grid-cols-2 gap-4">
+                                <Form.Field
+                                    {form}
+                                    name={`timeline.future[${index}].date`}
+                                >
+                                    <Form.Control>
+                                        {#snippet children({ props })}
+                                            <Form.Label>Date</Form.Label>
+                                            <Input
+                                                {...props}
+                                                placeholder="e.g., Q3 2024"
+                                            />
+                                        {/snippet}
+                                    </Form.Control>
+                                    <!-- {#if $errors.timeline?.future?.[index]?.date} -->
+                                    <Form.FieldErrors
+                                        class="text-destructive text-sm"
+                                    >
+                                        <!-- {$errors.timeline.future[index]
+                                                .date} -->
+                                    </Form.FieldErrors>
+                                    <!-- {/if} -->
+                                </Form.Field>
+
+                                <Form.Field
+                                    {form}
+                                    name={`timeline.future[${index}].type`}
+                                >
+                                    <Form.Control>
+                                        {#snippet children({ props })}
+                                            <Form.Label>Type</Form.Label>
+                                            <Select type="single" {...props}>
+                                                <SelectTrigger>
+                                                    <div class="placeholder">
+                                                        Select milestone type
+                                                    </div>
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="launch"
+                                                        >Launch</SelectItem
+                                                    >
+                                                    <SelectItem value="funding"
+                                                        >Funding</SelectItem
+                                                    >
+                                                    <SelectItem
+                                                        value="partnership"
+                                                        >Partnership</SelectItem
+                                                    >
+                                                    <SelectItem value="product"
+                                                        >Product</SelectItem
+                                                    >
+                                                    <SelectItem value="other"
+                                                        >Other</SelectItem
+                                                    >
+                                                </SelectContent>
+                                            </Select>
+                                        {/snippet}
+                                    </Form.Control>
+                                    <!-- {#if $errors.timeline?.future?.[index]?.type} -->
+                                    <Form.FieldErrors
+                                        class="text-destructive text-sm"
+                                    >
+                                        <!-- {$errors.timeline.future[index]
+                                                .type} -->
+                                    </Form.FieldErrors>
+                                    <!-- {/if} -->
+                                </Form.Field>
+                            </div>
+
+                            <Form.Field
+                                {form}
+                                name={`timeline.future[${index}].title`}
+                            >
+                                <Form.Control>
+                                    {#snippet children({ props })}
+                                        <Form.Label>Title</Form.Label>
+                                        <Input
+                                            {...props}
+                                            placeholder="e.g., Product Launch"
+                                        />
+                                    {/snippet}
+                                </Form.Control>
+                                <!-- {#if $errors.timeline?.future?.[index]?.title} -->
+                                <Form.FieldErrors
+                                    class="text-destructive text-sm"
+                                >
+                                    <!-- {$errors.timeline.future[index].title} -->
+                                </Form.FieldErrors>
+                                <!-- {/if} -->
+                            </Form.Field>
+
+                            <Form.Field
+                                {form}
+                                name={`timeline.future[${index}].description`}
+                            >
+                                <Form.Control>
+                                    {#snippet children({ props })}
+                                        <Form.Label>Description</Form.Label>
+                                        <Textarea
+                                            {...props}
+                                            placeholder="Describe the planned milestone"
+                                        />
+                                    {/snippet}
+                                </Form.Control>
+                                <!-- {#if $errors.timeline?.future?.[index]?.description} -->
+                                <Form.FieldErrors
+                                    class="text-destructive text-sm"
+                                >
+                                    <!-- {$errors.timeline.future[index]
+                                            .description} -->
+                                </Form.FieldErrors>
+                                <!-- {/if} -->
+                            </Form.Field>
+                        </div>
+                    {/each}
+                {/if}
+
+                <Button
+                    type="button"
+                    variant="outline"
+                    onclick={() => addFutureMilestone()}
+                    class="w-full"
+                >
+                    Add Future Milestone
+                </Button>
+            </div>
+        </CardContent>
+    </Card>
+
+    <!-- Submit Button -->
+    <div class="flex justify-end">
+        <Form.Button class="w-full" disabled={$delayed || $submitting}>
+            {#if $delayed || $submitting}
+                <div class="flex items-center justify-center gap-2">
+                    <LoaderCircle
+                        class="h-5 w-5 animate-spin"
+                        strokeWidth={2}
+                    />
+                    <span>Creating Startup...</span>
+                </div>
+            {:else}
+                <span>Create Startup</span>
+            {/if}
+        </Form.Button>
+    </div>
+</form>

--- a/frontend-sv/src/lib/components/NewStartupPreview.svelte
+++ b/frontend-sv/src/lib/components/NewStartupPreview.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+	import { Card, CardContent, CardHeader } from "@/components/ui/card";
+	import type { StartupSchema } from "@/schemas/startup-schema";
+	import type { Infer, SuperValidated } from "sveltekit-superforms";
+
+	let {
+		showPreview,
+		data,
+	}: {
+		showPreview: boolean;
+		data: { form: SuperValidated<Infer<StartupSchema>> };
+	} = $props();
+</script>
+
+{#if showPreview}
+	<div class="space-y-8">
+		<Card>
+			<CardHeader>
+				<!-- <div class="flex items-center gap-4">
+                                    {#if logoPreview}
+                                        <img
+                                            src={logoPreview}
+                                            alt="Startup logo"
+                                            class="w-16 h-16 rounded-lg object-cover"
+                                        />
+                                    {:else}
+                                        <div
+                                            class="w-16 h-16 rounded-lg bg-muted flex items-center justify-center"
+                                        >
+                                            <span class="text-2xl">🚀</span>
+                                        </div>
+                                    {/if}
+                                    <div>
+                                        <CardTitle
+                                            >{$formData.name ||
+                                                "Your Startup Name"}</CardTitle
+                                        >
+                                        <CardDescription
+                                            >{$formData.industry ||
+                                                "Industry"}</CardDescription
+                                        >
+                                    </div>
+                                </div> -->
+			</CardHeader>
+			<CardContent class="space-y-6">
+				<!-- <div>
+                                    <h3 class="text-lg font-semibold mb-2">
+                                        About
+                                    </h3>
+                                    <p class="text-muted-foreground">
+                                        {$formData.description ||
+                                            "Startup description will appear here"}
+                                    </p>
+                                </div>
+
+                                <div class="grid grid-cols-2 gap-4">
+                                    <div class="space-y-2">
+                                        <h3 class="text-lg font-semibold">
+                                            Key Metrics
+                                        </h3>
+                                        <div class="space-y-2">
+                                            <div
+                                                class="flex items-center gap-2"
+                                            >
+                                                <span
+                                                    class="text-muted-foreground"
+                                                    >Revenue:</span
+                                                >
+                                                <span
+                                                    >{$formData.metrics
+                                                        ?.revenue ||
+                                                        "Not specified"}</span
+                                                >
+                                            </div>
+                                            <div
+                                                class="flex items-center gap-2"
+                                            >
+                                                <span
+                                                    class="text-muted-foreground"
+                                                    >Growth:</span
+                                                >
+                                                <span
+                                                    >{$formData.metrics
+                                                        ?.growth ||
+                                                        "Not specified"}</span
+                                                >
+                                            </div>
+                                            <div
+                                                class="flex items-center gap-2"
+                                            >
+                                                <span
+                                                    class="text-muted-foreground"
+                                                    >Customers:</span
+                                                >
+                                                <span
+                                                    >{$formData.metrics
+                                                        ?.customers ||
+                                                        "Not specified"}</span
+                                                >
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="space-y-2">
+                                        <h3 class="text-lg font-semibold">
+                                            Funding
+                                        </h3>
+                                        <div class="space-y-2">
+                                            <div
+                                                class="flex items-center gap-2"
+                                            >
+                                                <span
+                                                    class="text-muted-foreground"
+                                                    >Total:</span
+                                                >
+                                                <span
+                                                    >{$formData.funding
+                                                        ?.total ||
+                                                        "Not specified"}</span
+                                                >
+                                            </div>
+                                            <div
+                                                class="flex items-center gap-2"
+                                            >
+                                                <span
+                                                    class="text-muted-foreground"
+                                                    >Last Round:</span
+                                                >
+                                                <span
+                                                    >{$formData.funding
+                                                        ?.lastRound ||
+                                                        "Not specified"}</span
+                                                >
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+ -->
+				<!-- More preview sections would follow the same pattern -->
+				<!-- ... -->
+			</CardContent>
+		</Card>
+	</div>
+{/if}

--- a/frontend-sv/src/lib/components/StartupCard.svelte
+++ b/frontend-sv/src/lib/components/StartupCard.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+  import * as Card from "$lib/components/ui/card";
+  import { Progress } from "$lib/components/ui/progress";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Button } from "$lib/components/ui/button";
+  import { Avatar } from "$lib/components/ui/avatar";
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+  import * as Tooltip from "$lib/components/ui/tooltip";
+  import { 
+    Users, 
+    DollarSign, 
+    Star, 
+    MoreHorizontal, 
+    FileEdit, 
+    ExternalLink, 
+    Trash2, 
+    Rocket,
+    Calendar,
+    MapPin,
+    TrendingUp
+  } from "@lucide/svelte/icons";
+
+  // Define startup props with types
+  export let startup: {
+    id: string;
+    name: string;
+    description: string;
+    logo?: string;
+    industry: string;
+    stage: string;
+    location: string;
+    foundedDate: string;
+    fundingRaised: number;
+    fundingGoal?: number;
+    fundingProgress?: number;
+    team: number;
+    featured?: boolean;
+    color?: string;
+    metrics?: {
+      revenue?: number;
+      users?: number;
+      growth?: number;
+    }
+  };
+
+  // Format currency
+  function formatCurrency(amount: number): string {
+    if (amount >= 1000000) {
+      return `$${(amount / 1000000).toFixed(1)}M`;
+    } else if (amount >= 1000) {
+      return `$${(amount / 1000).toFixed(0)}K`;
+    }
+    return `$${amount}`;
+  }
+
+  // Calculate funding progress percentage
+  let progress = startup.fundingProgress || 
+    (startup.fundingGoal ? Math.round((startup.fundingRaised / startup.fundingGoal) * 100) : 70);
+
+  // Format founding date
+  function formatDate(dateString: string): string {
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat('en-US', { 
+      month: 'short', 
+      year: 'numeric' 
+    }).format(date);
+  }
+
+  // Get stage colors
+  function getStageColor(stage: string): string {
+    switch(stage) {
+      case 'idea': return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
+      case 'mvp': return 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300';
+      case 'seed': return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
+      case 'series_a': return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300';
+      case 'series_b_plus': return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300';
+      default: return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
+    }
+  }
+
+  // Get stage display name
+  function getStageDisplay(stage: string): string {
+    switch(stage) {
+      case 'idea': return 'Idea';
+      case 'mvp': return 'MVP';
+      case 'seed': return 'Seed';
+      case 'series_a': return 'Series A';
+      case 'series_b_plus': return 'Series B+';
+      default: return stage;
+    }
+  }
+
+  // Generate abbreviation for logo fallback
+  function getInitials(name: string): string {
+    return name.split(' ')
+      .map(part => part[0])
+      .join('')
+      .toUpperCase()
+      .substring(0, 2);
+  }
+</script>
+
+<Card.Root class="overflow-hidden h-full transition duration-200 hover:shadow-md flex flex-col">
+  <Card.Header class="pb-3">
+    <div class="flex justify-between items-start">
+      <div class="flex items-center gap-3">
+        <div class="relative h-14 w-14 flex-shrink-0 rounded-md bg-muted overflow-hidden">
+          {#if startup.logo}
+            <img 
+              src="https://source.boringavatars.com/beam/120/{startup.name}?colors=4F46E5,0EA5E9,10B981,FACC15,F43F5E" 
+              alt="{startup.name} logo" 
+              class="absolute inset-0 object-cover h-full w-full"
+            />
+          {:else}
+            <div class="absolute inset-0 flex items-center justify-center font-semibold text-lg">
+              {getInitials(startup.name)}
+            </div>
+          {/if}
+        </div>
+        <div>
+          <div class="flex items-center gap-2">
+            <Card.Title>
+              {startup.name}
+            </Card.Title>
+            {#if startup.featured}
+              <Tooltip.Root>
+                <div>
+                  <span>
+                    <Star class="h-4 w-4 fill-amber-400 text-amber-400" />
+                  </span>
+                </div>
+                <Tooltip.Content>
+                  <p class="text-xs">Featured startup</p>
+                </Tooltip.Content>
+              </Tooltip.Root>
+            {/if}
+          </div>
+          <div class="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
+            <Badge variant="secondary" class={getStageColor(startup.stage)}>
+              {getStageDisplay(startup.stage)}
+            </Badge>
+            <span class="flex items-center gap-1">
+              <MapPin class="h-3 w-3" />
+              {startup.location}
+            </span>
+          </div>
+        </div>
+      </div>
+      
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <Button variant="ghost" size="icon" class="h-8 w-8">
+            <MoreHorizontal class="h-4 w-4" />
+            <span class="sr-only">Open menu</span>
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end" class="w-[200px]">
+          <DropdownMenu.Label>Actions</DropdownMenu.Label>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item>
+            <div class="flex items-center w-full">
+              <ExternalLink class="mr-2 h-4 w-4" />
+              <span>View Details</span>
+            </div>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item>
+            <div class="flex items-center w-full">
+              <FileEdit class="mr-2 h-4 w-4" />
+              <span>Edit Startup</span>
+            </div>
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item class="text-destructive focus:text-destructive">
+            <Trash2 class="mr-2 h-4 w-4" />
+            <span>Delete</span>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </div>
+  </Card.Header>
+  
+  <Card.Content class="flex-grow">
+    <p class="text-sm text-muted-foreground line-clamp-3">
+      {startup.description}
+    </p>
+    
+    <div class="mt-4 space-y-4">
+      <!-- Funding Progress -->
+      <div class="space-y-1">
+        <div class="flex justify-between text-sm">
+          <span class="text-muted-foreground flex items-center gap-1">
+            <DollarSign class="h-3.5 w-3.5" />
+            Funding Progress
+          </span>
+          <span class="font-medium">{progress}%</span>
+        </div>
+        <Progress value={progress} class="h-1.5" />
+        <div class="flex justify-between text-xs text-muted-foreground">
+          <span>Raised: {formatCurrency(startup.fundingRaised)}</span>
+          {#if startup.fundingGoal}
+            <span>Goal: {formatCurrency(startup.fundingGoal)}</span>
+          {/if}
+        </div>
+      </div>
+      
+      <!-- Key Metrics -->
+      <div class="grid grid-cols-3 gap-2 pt-2">
+        <div class="flex flex-col items-center justify-center p-2 rounded-md bg-muted/50">
+          <span class="text-xs text-muted-foreground">Founded</span>
+          <div class="flex items-center gap-1 mt-1">
+            <Calendar class="h-3 w-3 text-primary" />
+            <span class="font-semibold">{formatDate(startup.foundedDate)}</span>
+          </div>
+        </div>
+        
+        <div class="flex flex-col items-center justify-center p-2 rounded-md bg-muted/50">
+          <span class="text-xs text-muted-foreground">Team</span>
+          <div class="flex items-center gap-1 mt-1">
+            <Users class="h-3 w-3 text-primary" />
+            <span class="font-semibold">{startup.team}</span>
+          </div>
+        </div>
+        
+        {#if startup.metrics?.growth !== undefined}
+          <div class="flex flex-col items-center justify-center p-2 rounded-md bg-muted/50">
+            <span class="text-xs text-muted-foreground">Growth</span>
+            <div class="flex items-center gap-1 mt-1">
+              <TrendingUp class="h-3 w-3 text-primary" />
+              <span class="font-semibold">{startup.metrics.growth}%</span>
+            </div>
+          </div>
+        {:else}
+          <div class="flex flex-col items-center justify-center p-2 rounded-md bg-muted/50">
+            <span class="text-xs text-muted-foreground">Industry</span>
+            <div class="flex items-center gap-1 mt-1">
+              <Rocket class="h-3 w-3 text-primary" />
+              <span class="font-semibold capitalize">{startup.industry}</span>
+            </div>
+          </div>
+        {/if}
+      </div>
+    </div>
+  </Card.Content>
+  
+  <Card.Footer class="pt-0 mt-auto">
+      <Button variant="outline" class="w-full" onclick={() => window.location.href = '/dashboard/founder/startup/' + startup.id}>
+        View Details
+      </Button>
+  </Card.Footer>
+</Card.Root>

--- a/frontend-sv/src/lib/components/StartupList.svelte
+++ b/frontend-sv/src/lib/components/StartupList.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { Badge } from "$lib/components/ui/badge";
+  import { Button } from "$lib/components/ui/button";
+  import { Progress } from "$lib/components/ui/progress";
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+  import * as Tooltip from "$lib/components/ui/tooltip";
+  import { 
+    Users, 
+    DollarSign, 
+    Star, 
+    MoreHorizontal, 
+    FileEdit, 
+    ExternalLink, 
+    Trash2,
+    Calendar,
+    ArrowUpRight,
+    ChevronRight
+  } from "@lucide/svelte/icons";
+  
+  // Define startup props
+  export let startup: {
+    id: string;
+    name: string;
+    description: string;
+    logo?: string;
+    industry: string;
+    stage: string;
+    location: string;
+    foundedDate: string;
+    fundingRaised: number;
+    fundingGoal?: number;
+    fundingProgress?: number;
+    team: number;
+    featured?: boolean;
+  };
+  
+  // Format currency
+  function formatCurrency(amount: number): string {
+    if (amount >= 1000000) {
+      return `$${(amount / 1000000).toFixed(1)}M`;
+    } else if (amount >= 1000) {
+      return `$${(amount / 1000).toFixed(0)}K`;
+    }
+    return `$${amount}`;
+  }
+  
+  // Calculate funding progress
+  let progress = startup.fundingProgress || 
+    (startup.fundingGoal ? Math.round((startup.fundingRaised / startup.fundingGoal) * 100) : 70);
+  
+  // Get stage colors
+  function getStageColor(stage: string): string {
+    switch(stage) {
+      case 'idea': return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
+      case 'mvp': return 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300';
+      case 'seed': return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
+      case 'series_a': return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300';
+      case 'series_b_plus': return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300';
+      default: return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
+    }
+  }
+  
+  // Get stage display name
+  function getStageDisplay(stage: string): string {
+    switch(stage) {
+      case 'idea': return 'Idea';
+      case 'mvp': return 'MVP';
+      case 'seed': return 'Seed';
+      case 'series_a': return 'Series A';
+      case 'series_b_plus': return 'Series B+';
+      default: return stage;
+    }
+  }
+  
+  // Generate abbreviation for logo fallback
+  function getInitials(name: string): string {
+    return name.split(' ')
+      .map(part => part[0])
+      .join('')
+      .toUpperCase()
+      .substring(0, 2);
+  }
+</script>
+
+<div class="border rounded-lg transition-all hover:shadow-md p-5 bg-card">
+  <div class="flex items-center justify-between gap-4">
+    <!-- Left section - Logo and basic info -->
+    <div class="flex items-center gap-4">
+      <div class="relative h-12 w-12 flex-shrink-0 rounded-md bg-muted overflow-hidden">
+        {#if startup.logo}
+          <img 
+            src="https://source.boringavatars.com/beam/120/{startup.name}?colors=4F46E5,0EA5E9,10B981,FACC15,F43F5E" 
+            alt="{startup.name} logo" 
+            class="absolute inset-0 object-cover h-full w-full"
+          />
+        {:else}
+          <div class="absolute inset-0 flex items-center justify-center font-semibold text-lg">
+            {getInitials(startup.name)}
+          </div>
+        {/if}
+      </div>
+      
+      <div class="flex-grow min-w-0">
+        <div class="flex items-center gap-2">
+          <h3 class="font-semibold truncate text-foreground">
+            {startup.name}
+          </h3>
+          {#if startup.featured}
+            <Tooltip.Root>
+              <div>
+                <span>
+                  <Star class="h-4 w-4 fill-amber-400 text-amber-400 flex-shrink-0" />
+                </span>
+              </div>
+              <Tooltip.Content>
+                <p class="text-xs">Featured startup</p>
+              </Tooltip.Content>
+            </Tooltip.Root>
+          {/if}
+          <Badge variant="secondary" class={getStageColor(startup.stage) + " ml-1"}>
+            {getStageDisplay(startup.stage)}
+          </Badge>
+        </div>
+        
+        <p class="text-sm text-muted-foreground truncate md:max-w-[450px]">
+          {startup.description}
+        </p>
+        
+        <!-- Metrics for medium+ screens -->
+        <div class="hidden md:flex items-center gap-4 mt-2">
+          <div class="flex items-center gap-1.5 text-sm">
+            <DollarSign class="h-3.5 w-3.5 text-primary" />
+            <span>{formatCurrency(startup.fundingRaised)}</span>
+          </div>
+          
+          <div class="flex items-center gap-1.5 text-sm">
+            <Calendar class="h-3.5 w-3.5 text-primary" />
+            <span>Founded {new Date(startup.foundedDate).getFullYear()}</span>
+          </div>
+          
+          <div class="flex items-center gap-1.5 text-sm">
+            <Users class="h-3.5 w-3.5 text-primary" />
+            <span>{startup.team} team members</span>
+          </div>
+          
+          <!-- Funding Progress for larger screens -->
+          <div class="hidden lg:flex items-center gap-2 flex-grow max-w-xs">
+            <div class="w-full">
+              <Progress value={progress} class="h-1.5" />
+            </div>
+            <span class="text-xs whitespace-nowrap">{progress}%</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Right section - Actions -->
+    <div class="flex items-center gap-2">
+      <a href="/dashboard/founder/startup/{startup.id}" class="hidden md:block">
+        <Button variant="outline" size="sm" class="flex items-center gap-1">
+          <span>View</span>
+          <ArrowUpRight class="h-3.5 w-3.5" />
+        </Button>
+      </a>
+      
+      <a href="/dashboard/founder/startup/{startup.id}" class="md:hidden">
+        <Button variant="ghost" size="icon" class="h-8 w-8">
+          <ChevronRight class="h-4 w-4" />
+        </Button>
+      </a>
+      
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <Button variant="ghost" size="icon" class="h-8 w-8">
+            <MoreHorizontal class="h-4 w-4" />
+            <span class="sr-only">Open menu</span>
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end" class="w-[200px]">
+          <DropdownMenu.Label>Actions</DropdownMenu.Label>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item>
+            <div class="flex items-center w-full">
+              <ExternalLink class="mr-2 h-4 w-4" />
+              <span>View Details</span>
+            </div>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item>
+            <div class="flex items-center w-full">
+              <FileEdit class="mr-2 h-4 w-4" />
+              <span>Edit Startup</span>
+            </div>
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item class="text-destructive focus:text-destructive">
+            <Trash2 class="mr-2 h-4 w-4" />
+            <span>Delete</span>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </div>
+  </div>
+  
+  <!-- Mobile metrics row -->
+  <div class="flex items-center justify-between mt-4 md:hidden">
+    <div class="flex items-center gap-1.5 text-sm">
+      <DollarSign class="h-3.5 w-3.5 text-primary" />
+      <span>{formatCurrency(startup.fundingRaised)}</span>
+    </div>
+    
+    <div class="flex items-center gap-1.5 text-sm">
+      <Users class="h-3.5 w-3.5 text-primary" />
+      <span>{startup.team}</span>
+    </div>
+    
+    <div class="flex items-center gap-1 flex-grow max-w-[100px]">
+      <div class="w-full">
+        <Progress value={progress} class="h-1.5" />
+      </div>
+      <span class="text-xs whitespace-nowrap">{progress}%</span>
+    </div>
+  </div>
+</div>

--- a/frontend-sv/src/lib/components/app-sidebar.svelte
+++ b/frontend-sv/src/lib/components/app-sidebar.svelte
@@ -1,0 +1,171 @@
+<script lang="ts" module>
+	import AudioWaveform from "@lucide/svelte/icons/audio-waveform";
+	import BookOpen from "@lucide/svelte/icons/book-open";
+	import Bot from "@lucide/svelte/icons/bot";
+	import ChartPie from "@lucide/svelte/icons/chart-pie";
+	import Command from "@lucide/svelte/icons/command";
+	import Frame from "@lucide/svelte/icons/frame";
+	import GalleryVerticalEnd from "@lucide/svelte/icons/gallery-vertical-end";
+	import Map from "@lucide/svelte/icons/map";
+	import Settings2 from "@lucide/svelte/icons/settings-2";
+	import SquareTerminal from "@lucide/svelte/icons/square-terminal";
+
+	// This is sample data.
+	const data = {
+		user: {
+			name: "shadcn",
+			email: "m@example.com",
+			avatar: "/avatars/shadcn.jpg",
+		},
+		teams: [
+			{
+				name: "Acme Inc",
+				logo: GalleryVerticalEnd,
+				plan: "Enterprise",
+			},
+			{
+				name: "Acme Corp.",
+				logo: AudioWaveform,
+				plan: "Startup",
+			},
+			{
+				name: "Evil Corp.",
+				logo: Command,
+				plan: "Free",
+			},
+		],
+		navMain: [
+			{
+				title: "Playground",
+				url: "#",
+				icon: SquareTerminal,
+				isActive: true,
+				items: [
+					{
+						title: "History",
+						url: "#",
+					},
+					{
+						title: "Starred",
+						url: "#",
+					},
+					{
+						title: "Settings",
+						url: "#",
+					},
+				],
+			},
+			{
+				title: "Models",
+				url: "#",
+				icon: Bot,
+				items: [
+					{
+						title: "Genesis",
+						url: "#",
+					},
+					{
+						title: "Explorer",
+						url: "#",
+					},
+					{
+						title: "Quantum",
+						url: "#",
+					},
+				],
+			},
+			{
+				title: "Documentation",
+				url: "#",
+				icon: BookOpen,
+				items: [
+					{
+						title: "Introduction",
+						url: "#",
+					},
+					{
+						title: "Get Started",
+						url: "#",
+					},
+					{
+						title: "Tutorials",
+						url: "#",
+					},
+					{
+						title: "Changelog",
+						url: "#",
+					},
+				],
+			},
+			{
+				title: "Settings",
+				url: "#",
+				icon: Settings2,
+				items: [
+					{
+						title: "General",
+						url: "#",
+					},
+					{
+						title: "Team",
+						url: "#",
+					},
+					{
+						title: "Billing",
+						url: "#",
+					},
+					{
+						title: "Limits",
+						url: "#",
+					},
+				],
+			},
+		],
+		projects: [
+			{
+				name: "Design Engineering",
+				url: "#",
+				icon: Frame,
+			},
+			{
+				name: "Sales & Marketing",
+				url: "#",
+				icon: ChartPie,
+			},
+			{
+				name: "Travel",
+				url: "#",
+				icon: Map,
+			},
+		],
+	};
+</script>
+
+<script lang="ts">
+	import NavMain from "$lib/components/nav-main.svelte";
+	import NavProjects from "$lib/components/nav-projects.svelte";
+	import NavUser from "$lib/components/nav-user.svelte";
+	import TeamSwitcher from "$lib/components/team-switcher.svelte";
+	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		collapsible = "icon",
+		...restProps
+	}: ComponentProps<typeof Sidebar.Root> = $props();
+</script>
+
+<Sidebar.Root bind:ref {collapsible} {...restProps}>
+	<Sidebar.Header>
+		<TeamSwitcher teams={data.teams} />
+	</Sidebar.Header>
+	<Sidebar.Content>
+		<NavMain items={data.navMain} />
+		<NavProjects projects={data.projects} />
+	</Sidebar.Content>
+	<Sidebar.Footer>
+		<NavUser user={data.user} />
+	</Sidebar.Footer>
+	<Sidebar.Rail />
+</Sidebar.Root>

--- a/frontend-sv/src/lib/components/file-upload.svelte
+++ b/frontend-sv/src/lib/components/file-upload.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+    import { Button } from "$lib/components/ui/button";
+    import { createEventDispatcher } from "svelte";
+
+    export let accept = "*";
+    export let maxSize = 5; // In MB
+    export let multiple = false;
+    export let files: File[] = [];
+
+    const dispatch = createEventDispatcher<{
+        upload: { files: File[] };
+        remove: { index: number };
+    }>();
+
+    function formatFileSize(bytes: number): string {
+        if (bytes === 0) return "0 B";
+        const k = 1024;
+        const sizes = ["B", "KB", "MB", "GB"];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+    }
+
+    function handleFileChange(event: Event) {
+        const input = event.target as HTMLInputElement;
+        if (!input.files?.length) return;
+
+        const selectedFiles: File[] = [];
+        let hasInvalidSize = false;
+
+        for (let i = 0; i < input.files.length; i++) {
+            const file = input.files[i];
+            // Check file size
+            if (file.size > maxSize * 1024 * 1024) {
+                hasInvalidSize = true;
+                continue;
+            }
+            selectedFiles.push(file);
+        }
+
+        if (hasInvalidSize) {
+            alert(`One or more files exceed the maximum size of ${maxSize}MB.`);
+        }
+
+        if (selectedFiles.length) {
+            files = selectedFiles;
+            dispatch("upload", { files: selectedFiles });
+        }
+
+        // Reset input so the same file can be selected again if needed
+        input.value = "";
+    }
+
+    function removeFile(index: number) {
+        files = files.filter((_, i) => i !== index);
+        dispatch("remove", { index });
+    }
+
+    function removeAllFiles() {
+        files = [];
+        dispatch("remove", { index: -1 });
+    }
+</script>
+
+<div class="flex flex-col gap-2">
+    <div
+        class="border-2 border-dashed border-primary/20 rounded-lg p-6 text-center hover:border-primary/50 transition-colors"
+    >
+        <input
+            type="file"
+            {accept}
+            {multiple}
+            class="hidden"
+            id="file-upload"
+            onchange={handleFileChange}
+        />
+        <label for="file-upload" class="cursor-pointer">
+            <div class="flex flex-col items-center gap-2">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-8 w-8 text-muted-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+                    />
+                </svg>
+                <span class="text-sm font-medium">
+                    {#if files.length}
+                        Replace files
+                    {:else}
+                        Click to upload or drag and drop
+                    {/if}
+                </span>
+                <span class="text-xs text-muted-foreground">
+                    {accept.replace(/\*/g, "All")} (Max: {maxSize}MB)
+                </span>
+            </div>
+        </label>
+    </div>
+
+    {#if files.length > 0}
+        <div class="mt-2 space-y-2">
+            {#each files as file, index}
+                <div
+                    class="flex items-center justify-between p-2 bg-muted rounded-md"
+                >
+                    <div class="flex items-center gap-2 truncate">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="h-5 w-5 text-muted-foreground"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                        >
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                            />
+                        </svg>
+                        <div class="truncate">
+                            <p class="text-sm truncate">{file.name}</p>
+                            <p class="text-xs text-muted-foreground">
+                                {formatFileSize(file.size)}
+                            </p>
+                        </div>
+                    </div>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        onclick={() => removeFile(index)}
+                        class="h-8 w-8"
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="h-4 w-4"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                        >
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M6 18L18 6M6 6l12 12"
+                            />
+                        </svg>
+                        <span class="sr-only">Remove</span>
+                    </Button>
+                </div>
+            {/each}
+
+            {#if files.length > 1}
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onclick={removeAllFiles}
+                    class="w-full mt-2"
+                >
+                    Remove All Files
+                </Button>
+            {/if}
+        </div>
+    {/if}
+</div>

--- a/frontend-sv/src/lib/components/nav-main.svelte
+++ b/frontend-sv/src/lib/components/nav-main.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import * as Collapsible from "$lib/components/ui/collapsible/index.js";
+	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+	import ChevronRight from "@lucide/svelte/icons/chevron-right";
+
+	let {
+		items,
+	}: {
+		items: {
+			title: string;
+			url: string;
+			// this should be `Component` after @lucide/svelte updates types
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			icon?: any;
+			isActive?: boolean;
+			items?: {
+				title: string;
+				url: string;
+			}[];
+		}[];
+	} = $props();
+</script>
+
+<Sidebar.Group>
+	<Sidebar.GroupLabel>Platform</Sidebar.GroupLabel>
+	<Sidebar.Menu>
+		{#each items as mainItem (mainItem.title)}
+			<Collapsible.Root open={mainItem.isActive} class="group/collapsible">
+				{#snippet child({ props })}
+					<Sidebar.MenuItem {...props}>
+						<Collapsible.Trigger>
+							{#snippet child({ props })}
+								<Sidebar.MenuButton {...props}>
+									{#snippet tooltipContent()}
+										{mainItem.title}
+									{/snippet}
+									{#if mainItem.icon}
+										<mainItem.icon />
+									{/if}
+									<span>{mainItem.title}</span>
+									<ChevronRight
+										class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+									/>
+								</Sidebar.MenuButton>
+							{/snippet}
+						</Collapsible.Trigger>
+						<Collapsible.Content>
+							{#if mainItem.items}
+								<Sidebar.MenuSub>
+									{#each mainItem.items as subItem (subItem.title)}
+										<Sidebar.MenuSubItem>
+											<Sidebar.MenuSubButton>
+												{#snippet child({ props })}
+													<a href={subItem.url} {...props}>
+														<span>{subItem.title}</span>
+													</a>
+												{/snippet}
+											</Sidebar.MenuSubButton>
+										</Sidebar.MenuSubItem>
+									{/each}
+								</Sidebar.MenuSub>
+							{/if}
+						</Collapsible.Content>
+					</Sidebar.MenuItem>
+				{/snippet}
+			</Collapsible.Root>
+		{/each}
+	</Sidebar.Menu>
+</Sidebar.Group>

--- a/frontend-sv/src/lib/components/nav-projects.svelte
+++ b/frontend-sv/src/lib/components/nav-projects.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
+	import { useSidebar } from "$lib/components/ui/sidebar/context.svelte.js";
+	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+	import Ellipsis from "@lucide/svelte/icons/ellipsis";
+	import Folder from "@lucide/svelte/icons/folder";
+	import Forward from "@lucide/svelte/icons/forward";
+	import Trash2 from "@lucide/svelte/icons/trash-2";
+
+	let {
+		projects,
+	}: {
+		projects: {
+			name: string;
+			url: string;
+			// This should be `Component` after @lucide/svelte updates types
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			icon: any;
+		}[];
+	} = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<Sidebar.Group class="group-data-[collapsible=icon]:hidden">
+	<Sidebar.GroupLabel>Projects</Sidebar.GroupLabel>
+	<Sidebar.Menu>
+		{#each projects as item (item.name)}
+			<Sidebar.MenuItem>
+				<Sidebar.MenuButton>
+					{#snippet child({ props })}
+						<a href={item.url} {...props}>
+							<item.icon />
+							<span>{item.name}</span>
+						</a>
+					{/snippet}
+				</Sidebar.MenuButton>
+				<DropdownMenu.Root>
+					<DropdownMenu.Trigger>
+						{#snippet child({ props })}
+							<Sidebar.MenuAction showOnHover {...props}>
+								<Ellipsis />
+								<span class="sr-only">More</span>
+							</Sidebar.MenuAction>
+						{/snippet}
+					</DropdownMenu.Trigger>
+					<DropdownMenu.Content
+						class="w-48 rounded-lg"
+						side={sidebar.isMobile ? "bottom" : "right"}
+						align={sidebar.isMobile ? "end" : "start"}
+					>
+						<DropdownMenu.Item>
+							<Folder class="text-muted-foreground" />
+							<span>View Project</span>
+						</DropdownMenu.Item>
+						<DropdownMenu.Item>
+							<Forward class="text-muted-foreground" />
+							<span>Share Project</span>
+						</DropdownMenu.Item>
+						<DropdownMenu.Separator />
+						<DropdownMenu.Item>
+							<Trash2 class="text-muted-foreground" />
+							<span>Delete Project</span>
+						</DropdownMenu.Item>
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+			</Sidebar.MenuItem>
+		{/each}
+		<Sidebar.MenuItem>
+			<Sidebar.MenuButton class="text-sidebar-foreground/70">
+				<Ellipsis class="text-sidebar-foreground/70" />
+				<span>More</span>
+			</Sidebar.MenuButton>
+		</Sidebar.MenuItem>
+	</Sidebar.Menu>
+</Sidebar.Group>

--- a/frontend-sv/src/lib/components/nav-user.svelte
+++ b/frontend-sv/src/lib/components/nav-user.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import * as Avatar from "$lib/components/ui/avatar/index.js";
+	import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
+	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+	import { useSidebar } from "$lib/components/ui/sidebar/index.js";
+	import BadgeCheck from "@lucide/svelte/icons/badge-check";
+	import Bell from "@lucide/svelte/icons/bell";
+	import ChevronsUpDown from "@lucide/svelte/icons/chevrons-up-down";
+	import CreditCard from "@lucide/svelte/icons/credit-card";
+	import LogOut from "@lucide/svelte/icons/log-out";
+	import Sparkles from "@lucide/svelte/icons/sparkles";
+
+	let { user }: { user: { name: string; email: string; avatar: string } } = $props();
+	const sidebar = useSidebar();
+</script>
+
+<Sidebar.Menu>
+	<Sidebar.MenuItem>
+		<DropdownMenu.Root>
+			<DropdownMenu.Trigger>
+				{#snippet child({ props })}
+					<Sidebar.MenuButton
+						size="lg"
+						class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+						{...props}
+					>
+						<Avatar.Root class="h-8 w-8 rounded-lg">
+							<Avatar.Image src={user.avatar} alt={user.name} />
+							<Avatar.Fallback class="rounded-lg">CN</Avatar.Fallback>
+						</Avatar.Root>
+						<div class="grid flex-1 text-left text-sm leading-tight">
+							<span class="truncate font-semibold">{user.name}</span>
+							<span class="truncate text-xs">{user.email}</span>
+						</div>
+						<ChevronsUpDown class="ml-auto size-4" />
+					</Sidebar.MenuButton>
+				{/snippet}
+			</DropdownMenu.Trigger>
+			<DropdownMenu.Content
+				class="w-[var(--bits-dropdown-menu-anchor-width)] min-w-56 rounded-lg"
+				side={sidebar.isMobile ? "bottom" : "right"}
+				align="end"
+				sideOffset={4}
+			>
+				<DropdownMenu.Label class="p-0 font-normal">
+					<div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+						<Avatar.Root class="h-8 w-8 rounded-lg">
+							<Avatar.Image src={user.avatar} alt={user.name} />
+							<Avatar.Fallback class="rounded-lg">CN</Avatar.Fallback>
+						</Avatar.Root>
+						<div class="grid flex-1 text-left text-sm leading-tight">
+							<span class="truncate font-semibold">{user.name}</span>
+							<span class="truncate text-xs">{user.email}</span>
+						</div>
+					</div>
+				</DropdownMenu.Label>
+				<DropdownMenu.Separator />
+				<DropdownMenu.Group>
+					<DropdownMenu.Item>
+						<Sparkles />
+						Upgrade to Pro
+					</DropdownMenu.Item>
+				</DropdownMenu.Group>
+				<DropdownMenu.Separator />
+				<DropdownMenu.Group>
+					<DropdownMenu.Item>
+						<BadgeCheck />
+						Account
+					</DropdownMenu.Item>
+					<DropdownMenu.Item>
+						<CreditCard />
+						Billing
+					</DropdownMenu.Item>
+					<DropdownMenu.Item>
+						<Bell />
+						Notifications
+					</DropdownMenu.Item>
+				</DropdownMenu.Group>
+				<DropdownMenu.Separator />
+				<DropdownMenu.Item>
+					<LogOut />
+					Log out
+				</DropdownMenu.Item>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
+	</Sidebar.MenuItem>
+</Sidebar.Menu>

--- a/frontend-sv/src/lib/components/sidebar-page.svelte
+++ b/frontend-sv/src/lib/components/sidebar-page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import AppSidebar from "$lib/components/app-sidebar.svelte";
+	import * as Breadcrumb from "$lib/components/ui/breadcrumb/index.js";
+	import { Separator } from "$lib/components/ui/separator/index.js";
+	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+</script>
+
+<Sidebar.Provider>
+	<AppSidebar />
+	<Sidebar.Inset>
+		<header
+			class="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12"
+		>
+			<div class="flex items-center gap-2 px-4">
+				<Sidebar.Trigger class="-ml-1" />
+				<Separator orientation="vertical" class="mr-2 h-4" />
+				<Breadcrumb.Root>
+					<Breadcrumb.List>
+						<Breadcrumb.Item class="hidden md:block">
+							<Breadcrumb.Link href="#">Building Your Application</Breadcrumb.Link>
+						</Breadcrumb.Item>
+						<Breadcrumb.Separator class="hidden md:block" />
+						<Breadcrumb.Item>
+							<Breadcrumb.Page>Data Fetching</Breadcrumb.Page>
+						</Breadcrumb.Item>
+					</Breadcrumb.List>
+				</Breadcrumb.Root>
+			</div>
+		</header>
+		<div class="flex flex-1 flex-col gap-4 p-4 pt-0">
+			<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+				<div class="bg-muted/50 aspect-video rounded-xl"></div>
+				<div class="bg-muted/50 aspect-video rounded-xl"></div>
+				<div class="bg-muted/50 aspect-video rounded-xl"></div>
+			</div>
+			<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+		</div>
+	</Sidebar.Inset>
+</Sidebar.Provider>

--- a/frontend-sv/src/lib/components/team-switcher.svelte
+++ b/frontend-sv/src/lib/components/team-switcher.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
+	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+	import { useSidebar } from "$lib/components/ui/sidebar/index.js";
+	import ChevronsUpDown from "@lucide/svelte/icons/chevrons-up-down";
+	import Plus from "@lucide/svelte/icons/plus";
+
+	// This should be `Component` after @lucide/svelte updates types
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let { teams }: { teams: { name: string; logo: any; plan: string }[] } = $props();
+	const sidebar = useSidebar();
+
+	let activeTeam = $state(teams[0]);
+</script>
+
+<Sidebar.Menu>
+	<Sidebar.MenuItem>
+		<DropdownMenu.Root>
+			<DropdownMenu.Trigger>
+				{#snippet child({ props })}
+					<Sidebar.MenuButton
+						{...props}
+						size="lg"
+						class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+					>
+						<div
+							class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+						>
+							<activeTeam.logo class="size-4" />
+						</div>
+						<div class="grid flex-1 text-left text-sm leading-tight">
+							<span class="truncate font-semibold">
+								{activeTeam.name}
+							</span>
+							<span class="truncate text-xs">{activeTeam.plan}</span>
+						</div>
+						<ChevronsUpDown class="ml-auto" />
+					</Sidebar.MenuButton>
+				{/snippet}
+			</DropdownMenu.Trigger>
+			<DropdownMenu.Content
+				class="w-[var(--bits-dropdown-menu-anchor-width)] min-w-56 rounded-lg"
+				align="start"
+				side={sidebar.isMobile ? "bottom" : "right"}
+				sideOffset={4}
+			>
+				<DropdownMenu.Label class="text-muted-foreground text-xs">Teams</DropdownMenu.Label>
+				{#each teams as team, index (team.name)}
+					<DropdownMenu.Item onSelect={() => (activeTeam = team)} class="gap-2 p-2">
+						<div class="flex size-6 items-center justify-center rounded-sm border">
+							<team.logo class="size-4 shrink-0" />
+						</div>
+						{team.name}
+						<DropdownMenu.Shortcut>⌘{index + 1}</DropdownMenu.Shortcut>
+					</DropdownMenu.Item>
+				{/each}
+				<DropdownMenu.Separator />
+				<DropdownMenu.Item class="gap-2 p-2">
+					<div
+						class="bg-background flex size-6 items-center justify-center rounded-md border"
+					>
+						<Plus class="size-4" />
+					</div>
+					<div class="text-muted-foreground font-medium">Add team</div>
+				</DropdownMenu.Item>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
+	</Sidebar.MenuItem>
+</Sidebar.Menu>

--- a/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-ellipsis.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import Ellipsis from "@lucide/svelte/icons/ellipsis";
+	import type { WithElementRef, WithoutChildren } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	role="presentation"
+	aria-hidden="true"
+	class={cn("flex size-9 items-center justify-center", className)}
+	{...restProps}
+>
+	<Ellipsis class="size-4" />
+	<span class="sr-only">More</span>
+</span>

--- a/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-item.svelte
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-item.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLLiAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLLiAttributes> = $props();
+</script>
+
+<li bind:this={ref} class={cn("inline-flex items-center gap-1.5", className)} {...restProps}>
+	{@render children?.()}
+</li>

--- a/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { HTMLAnchorAttributes } from "svelte/elements";
+	import type { Snippet } from "svelte";
+	import type { WithElementRef } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		href = undefined,
+		child,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAnchorAttributes> & {
+		child?: Snippet<[{ props: HTMLAnchorAttributes }]>;
+	} = $props();
+
+	const attrs = $derived({
+		class: cn("hover:text-foreground transition-colors", className),
+		href,
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: attrs })}
+{:else}
+	<a bind:this={ref} {...attrs}>
+		{@render children?.()}
+	</a>
+{/if}

--- a/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-list.svelte
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-list.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLOlAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLOlAttributes> = $props();
+</script>
+
+<ol
+	bind:this={ref}
+	class={cn(
+		"text-muted-foreground flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</ol>

--- a/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-page.svelte
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	role="link"
+	aria-disabled="true"
+	aria-current="page"
+	class={cn("text-foreground font-normal", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-separator.svelte
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb-separator.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import ChevronRight from "@lucide/svelte/icons/chevron-right";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLLiAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLLiAttributes> = $props();
+</script>
+
+<li
+	role="presentation"
+	aria-hidden="true"
+	class={cn("[&>svg]:size-3.5", className)}
+	bind:this={ref}
+	{...restProps}
+>
+	{#if children}
+		{@render children?.()}
+	{:else}
+		<ChevronRight />
+	{/if}
+</li>

--- a/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb.svelte
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/breadcrumb.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<nav class={className} bind:this={ref} aria-label="breadcrumb" {...restProps}>
+	{@render children?.()}
+</nav>

--- a/frontend-sv/src/lib/components/ui/breadcrumb/index.ts
+++ b/frontend-sv/src/lib/components/ui/breadcrumb/index.ts
@@ -1,0 +1,25 @@
+import Root from "./breadcrumb.svelte";
+import Ellipsis from "./breadcrumb-ellipsis.svelte";
+import Item from "./breadcrumb-item.svelte";
+import Separator from "./breadcrumb-separator.svelte";
+import Link from "./breadcrumb-link.svelte";
+import List from "./breadcrumb-list.svelte";
+import Page from "./breadcrumb-page.svelte";
+
+export {
+	Root,
+	Ellipsis,
+	Item,
+	Separator,
+	Link,
+	List,
+	Page,
+	//
+	Root as Breadcrumb,
+	Ellipsis as BreadcrumbEllipsis,
+	Item as BreadcrumbItem,
+	Separator as BreadcrumbSeparator,
+	Link as BreadcrumbLink,
+	List as BreadcrumbList,
+	Page as BreadcrumbPage,
+};

--- a/frontend-sv/src/lib/components/ui/collapsible/index.ts
+++ b/frontend-sv/src/lib/components/ui/collapsible/index.ts
@@ -1,0 +1,15 @@
+import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+
+const Root: typeof CollapsiblePrimitive.Root = CollapsiblePrimitive.Root;
+const Trigger: typeof CollapsiblePrimitive.Trigger = CollapsiblePrimitive.Trigger;
+const Content: typeof CollapsiblePrimitive.Content = CollapsiblePrimitive.Content;
+
+export {
+	Root,
+	Content,
+	Trigger,
+	//
+	Root as Collapsible,
+	Content as CollapsibleContent,
+	Trigger as CollapsibleTrigger,
+};

--- a/frontend-sv/src/lib/components/ui/sidebar/constants.ts
+++ b/frontend-sv/src/lib/components/ui/sidebar/constants.ts
@@ -1,0 +1,6 @@
+export const SIDEBAR_COOKIE_NAME = "sidebar:state";
+export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+export const SIDEBAR_WIDTH = "16rem";
+export const SIDEBAR_WIDTH_MOBILE = "18rem";
+export const SIDEBAR_WIDTH_ICON = "3rem";
+export const SIDEBAR_KEYBOARD_SHORTCUT = "b";

--- a/frontend-sv/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/frontend-sv/src/lib/components/ui/sidebar/context.svelte.ts
@@ -1,0 +1,81 @@
+import { IsMobile } from "$lib/hooks/is-mobile.svelte.js";
+import { getContext, setContext } from "svelte";
+import { SIDEBAR_KEYBOARD_SHORTCUT } from "./constants.js";
+
+type Getter<T> = () => T;
+
+export type SidebarStateProps = {
+	/**
+	 * A getter function that returns the current open state of the sidebar.
+	 * We use a getter function here to support `bind:open` on the `Sidebar.Provider`
+	 * component.
+	 */
+	open: Getter<boolean>;
+
+	/**
+	 * A function that sets the open state of the sidebar. To support `bind:open`, we need
+	 * a source of truth for changing the open state to ensure it will be synced throughout
+	 * the sub-components and any `bind:` references.
+	 */
+	setOpen: (open: boolean) => void;
+};
+
+class SidebarState {
+	readonly props: SidebarStateProps;
+	open = $derived.by(() => this.props.open());
+	openMobile = $state(false);
+	setOpen: SidebarStateProps["setOpen"];
+	#isMobile: IsMobile;
+	state = $derived.by(() => (this.open ? "expanded" : "collapsed"));
+
+	constructor(props: SidebarStateProps) {
+		this.setOpen = props.setOpen;
+		this.#isMobile = new IsMobile();
+		this.props = props;
+	}
+
+	// Convenience getter for checking if the sidebar is mobile
+	// without this, we would need to use `sidebar.isMobile.current` everywhere
+	get isMobile() {
+		return this.#isMobile.current;
+	}
+
+	// Event handler to apply to the `<svelte:window>`
+	handleShortcutKeydown = (e: KeyboardEvent) => {
+		if (e.key === SIDEBAR_KEYBOARD_SHORTCUT && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			this.toggle();
+		}
+	};
+
+	setOpenMobile = (value: boolean) => {
+		this.openMobile = value;
+	};
+
+	toggle = () => {
+		return this.#isMobile.current
+			? (this.openMobile = !this.openMobile)
+			: this.setOpen(!this.open);
+	};
+}
+
+const SYMBOL_KEY = "scn-sidebar";
+
+/**
+ * Instantiates a new `SidebarState` instance and sets it in the context.
+ *
+ * @param props The constructor props for the `SidebarState` class.
+ * @returns  The `SidebarState` instance.
+ */
+export function setSidebar(props: SidebarStateProps): SidebarState {
+	return setContext(Symbol.for(SYMBOL_KEY), new SidebarState(props));
+}
+
+/**
+ * Retrieves the `SidebarState` instance from the context. This is a class instance,
+ * so you cannot destructure it.
+ * @returns The `SidebarState` instance.
+ */
+export function useSidebar(): SidebarState {
+	return getContext(Symbol.for(SYMBOL_KEY));
+}

--- a/frontend-sv/src/lib/components/ui/sidebar/index.ts
+++ b/frontend-sv/src/lib/components/ui/sidebar/index.ts
@@ -1,0 +1,75 @@
+import { useSidebar } from "./context.svelte.js";
+import Content from "./sidebar-content.svelte";
+import Footer from "./sidebar-footer.svelte";
+import GroupAction from "./sidebar-group-action.svelte";
+import GroupContent from "./sidebar-group-content.svelte";
+import GroupLabel from "./sidebar-group-label.svelte";
+import Group from "./sidebar-group.svelte";
+import Header from "./sidebar-header.svelte";
+import Input from "./sidebar-input.svelte";
+import Inset from "./sidebar-inset.svelte";
+import MenuAction from "./sidebar-menu-action.svelte";
+import MenuBadge from "./sidebar-menu-badge.svelte";
+import MenuButton from "./sidebar-menu-button.svelte";
+import MenuItem from "./sidebar-menu-item.svelte";
+import MenuSkeleton from "./sidebar-menu-skeleton.svelte";
+import MenuSubButton from "./sidebar-menu-sub-button.svelte";
+import MenuSubItem from "./sidebar-menu-sub-item.svelte";
+import MenuSub from "./sidebar-menu-sub.svelte";
+import Menu from "./sidebar-menu.svelte";
+import Provider from "./sidebar-provider.svelte";
+import Rail from "./sidebar-rail.svelte";
+import Separator from "./sidebar-separator.svelte";
+import Trigger from "./sidebar-trigger.svelte";
+import Root from "./sidebar.svelte";
+
+export {
+	Content,
+	Footer,
+	Group,
+	GroupAction,
+	GroupContent,
+	GroupLabel,
+	Header,
+	Input,
+	Inset,
+	Menu,
+	MenuAction,
+	MenuBadge,
+	MenuButton,
+	MenuItem,
+	MenuSkeleton,
+	MenuSub,
+	MenuSubButton,
+	MenuSubItem,
+	Provider,
+	Rail,
+	Root,
+	Separator,
+	//
+	Root as Sidebar,
+	Content as SidebarContent,
+	Footer as SidebarFooter,
+	Group as SidebarGroup,
+	GroupAction as SidebarGroupAction,
+	GroupContent as SidebarGroupContent,
+	GroupLabel as SidebarGroupLabel,
+	Header as SidebarHeader,
+	Input as SidebarInput,
+	Inset as SidebarInset,
+	Menu as SidebarMenu,
+	MenuAction as SidebarMenuAction,
+	MenuBadge as SidebarMenuBadge,
+	MenuButton as SidebarMenuButton,
+	MenuItem as SidebarMenuItem,
+	MenuSkeleton as SidebarMenuSkeleton,
+	MenuSub as SidebarMenuSub,
+	MenuSubButton as SidebarMenuSubButton,
+	MenuSubItem as SidebarMenuSubItem,
+	Provider as SidebarProvider,
+	Rail as SidebarRail,
+	Separator as SidebarSeparator,
+	Trigger as SidebarTrigger,
+	Trigger,
+	useSidebar,
+};

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-content.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-content.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-sidebar="content"
+	class={cn(
+		"flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-footer.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-footer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-sidebar="footer"
+	class={cn("flex flex-col gap-2 p-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-group-action.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-group-action.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { Snippet } from "svelte";
+	import type { HTMLButtonAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		child,
+		...restProps
+	}: WithElementRef<HTMLButtonAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const propObj = $derived({
+		class: cn(
+			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-none transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+			// Increases the hit area of the button on mobile.
+			"after:absolute after:-inset-2 after:md:hidden",
+			"group-data-[collapsible=icon]:hidden",
+			className
+		),
+		"data-sidebar": "group-action",
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: propObj })}
+{:else}
+	<button bind:this={ref} {...propObj}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-group-content.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-group-content.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-sidebar="group-content"
+	class={cn("w-full text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-group-label.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-group-label.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { Snippet } from "svelte";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		children,
+		child,
+		class: className,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			"text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-none transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+			"group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+			className
+		),
+		"data-sidebar": "group-label",
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-group.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-group.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-sidebar="group"
+	class={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-header.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-header.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-sidebar="header"
+	class={cn("flex flex-col gap-2 p-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-input.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-input.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Input } from "$lib/components/ui/input/index.js";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(""),
+		class: className,
+		...restProps
+	}: ComponentProps<typeof Input> = $props();
+</script>
+
+<Input
+	bind:ref
+	bind:value
+	data-sidebar="input"
+	class={cn(
+		"bg-background focus-visible:ring-sidebar-ring h-8 w-full shadow-none focus-visible:ring-2",
+		className
+	)}
+	{...restProps}
+/>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<main
+	bind:this={ref}
+	class={cn(
+		"bg-background relative flex min-h-svh flex-1 flex-col",
+		"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</main>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { Snippet } from "svelte";
+	import type { HTMLButtonAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		showOnHover = false,
+		children,
+		child,
+		...restProps
+	}: WithElementRef<HTMLButtonAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		showOnHover?: boolean;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-none transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+			// Increases the hit area of the button on mobile.
+			"after:absolute after:-inset-2 after:md:hidden",
+			"peer-data-[size=sm]/menu-button:top-1",
+			"peer-data-[size=default]/menu-button:top-1.5",
+			"peer-data-[size=lg]/menu-button:top-2.5",
+			"group-data-[collapsible=icon]:hidden",
+			showOnHover &&
+				"peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+			className
+		),
+		"data-sidebar": "menu-action",
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<button bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-badge.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-badge.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-sidebar="menu-badge"
+	class={cn(
+		"text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums",
+		"peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+		"peer-data-[size=sm]/menu-button:top-1",
+		"peer-data-[size=default]/menu-button:top-1.5",
+		"peer-data-[size=lg]/menu-button:top-2.5",
+		"group-data-[collapsible=icon]:hidden",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
@@ -1,0 +1,97 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const sidebarMenuButtonVariants = tv({
+		base: "peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none transition-[width,height,padding] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+		variants: {
+			variant: {
+				default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+				outline:
+					"bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+			},
+			size: {
+				default: "h-8 text-sm",
+				sm: "h-7 text-xs",
+				lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	});
+
+	export type SidebarMenuButtonVariant = VariantProps<
+		typeof sidebarMenuButtonVariants
+	>["variant"];
+	export type SidebarMenuButtonSize = VariantProps<typeof sidebarMenuButtonVariants>["size"];
+</script>
+
+<script lang="ts">
+	import * as Tooltip from "$lib/components/ui/tooltip/index.js";
+	import { cn } from "$lib/utils.js";
+	import { mergeProps, type WithElementRef, type WithoutChildrenOrChild } from "bits-ui";
+	import type { ComponentProps, Snippet } from "svelte";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		child,
+		variant = "default",
+		size = "default",
+		isActive = false,
+		tooltipContent,
+		tooltipContentProps,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+		isActive?: boolean;
+		variant?: SidebarMenuButtonVariant;
+		size?: SidebarMenuButtonSize;
+		tooltipContent?: Snippet;
+		tooltipContentProps?: WithoutChildrenOrChild<ComponentProps<typeof Tooltip.Content>>;
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const sidebar = useSidebar();
+
+	const buttonProps = $derived({
+		class: cn(sidebarMenuButtonVariants({ variant, size }), className),
+		"data-sidebar": "menu-button",
+		"data-size": size,
+		"data-active": isActive,
+		...restProps,
+	});
+</script>
+
+{#snippet Button({ props }: { props?: Record<string, unknown> })}
+	{@const mergedProps = mergeProps(buttonProps, props)}
+	{#if child}
+		{@render child({ props: mergedProps })}
+	{:else}
+		<button bind:this={ref} {...mergedProps}>
+			{@render children?.()}
+		</button>
+	{/if}
+{/snippet}
+
+{#if !tooltipContent}
+	{@render Button({})}
+{:else}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				{@render Button({ props })}
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content
+			side="right"
+			align="center"
+			hidden={sidebar.state !== "collapsed" || sidebar.isMobile}
+			children={tooltipContent}
+			{...tooltipContentProps}
+		/>
+	</Tooltip.Root>
+{/if}

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-item.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-item.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLLIElement>, HTMLLIElement> = $props();
+</script>
+
+<li
+	bind:this={ref}
+	data-sidebar="menu-item"
+	class={cn("group/menu-item relative", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</li>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Skeleton } from "$lib/components/ui/skeleton/index.js";
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		showIcon = false,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		showIcon?: boolean;
+	} = $props();
+
+	// Random width between 50% and 90%
+	const width = `${Math.floor(Math.random() * 40) + 50}%`;
+</script>
+
+<div
+	bind:this={ref}
+	data-sidebar="menu-skeleton"
+	class={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+	{...restProps}
+>
+	{#if showIcon}
+		<Skeleton class="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />
+	{/if}
+	<Skeleton
+		class="h-4 max-w-[var(--skeleton-width)] flex-1"
+		data-sidebar="menu-skeleton-text"
+		style="--skeleton-width: {width};"
+	/>
+	{@render children?.()}
+</div>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { Snippet } from "svelte";
+	import type { HTMLAnchorAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		children,
+		child,
+		class: className,
+		size = "md",
+		isActive,
+		...restProps
+	}: WithElementRef<HTMLAnchorAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		size?: "sm" | "md";
+		isActive?: boolean;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+			"data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+			size === "sm" && "text-xs",
+			size === "md" && "text-sm",
+			"group-data-[collapsible=icon]:hidden",
+			className
+		),
+		"data-sidebar": "menu-sub-button",
+		"data-size": size,
+		"data-active": isActive,
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<a bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</a>
+{/if}

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-sub-item.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-sub-item.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLLIElement>> = $props();
+</script>
+
+<li bind:this={ref} data-sidebar="menu-sub-item" {...restProps}>
+	{@render children?.()}
+</li>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-sub.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu-sub.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();
+</script>
+
+<ul
+	bind:this={ref}
+	data-sidebar="menu-sub"
+	class={cn(
+		"border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+		"group-data-[collapsible=icon]:hidden",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</ul>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-menu.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLUListElement>, HTMLUListElement> = $props();
+</script>
+
+<ul
+	bind:this={ref}
+	data-sidebar="menu"
+	class={cn("flex w-full min-w-0 flex-col gap-1", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</ul>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import * as Tooltip from "$lib/components/ui/tooltip/index.js";
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import {
+		SIDEBAR_COOKIE_MAX_AGE,
+		SIDEBAR_COOKIE_NAME,
+		SIDEBAR_WIDTH,
+		SIDEBAR_WIDTH_ICON,
+	} from "./constants.js";
+	import { setSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		open = $bindable(true),
+		onOpenChange = () => {},
+		class: className,
+		style,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		open?: boolean;
+		onOpenChange?: (open: boolean) => void;
+	} = $props();
+
+	const sidebar = setSidebar({
+		open: () => open,
+		setOpen: (value: boolean) => {
+			open = value;
+			onOpenChange(value);
+
+			// This sets the cookie to keep the sidebar state.
+			document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+		},
+	});
+</script>
+
+<svelte:window onkeydown={sidebar.handleShortcutKeydown} />
+
+<Tooltip.Provider delayDuration={0}>
+	<div
+		style="--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
+		class={cn(
+			"group/sidebar-wrapper has-[[data-variant=inset]]:bg-sidebar flex min-h-svh w-full",
+			className
+		)}
+		bind:this={ref}
+		{...restProps}
+	>
+		{@render children?.()}
+	</div>
+</Tooltip.Provider>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-rail.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-rail.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<button
+	bind:this={ref}
+	data-sidebar="rail"
+	aria-label="Toggle Sidebar"
+	tabIndex={-1}
+	onclick={() => sidebar.toggle()}
+	title="Toggle Sidebar"
+	class={cn(
+		"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+		"[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+		"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+		"group-data-[collapsible=offcanvas]:hover:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+		"[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+		"[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</button>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-separator.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-separator.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { Separator } from "$lib/components/ui/separator/index.js";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ComponentProps<typeof Separator> = $props();
+</script>
+
+<Separator
+	bind:ref
+	data-sidebar="separator"
+	class={cn("bg-sidebar-border mx-2 w-auto", className)}
+	{...restProps}
+/>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { Button } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+	import PanelLeft from "@lucide/svelte/icons/panel-left";
+	import type { ComponentProps } from "svelte";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		onclick,
+		...restProps
+	}: ComponentProps<typeof Button> & {
+		onclick?: (e: MouseEvent) => void;
+	} = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<Button
+	type="button"
+	onclick={(e) => {
+		onclick?.(e);
+		sidebar.toggle();
+	}}
+	data-sidebar="trigger"
+	variant="ghost"
+	size="icon"
+	class={cn("h-7 w-7", className)}
+	{...restProps}
+>
+	<PanelLeft />
+	<span class="sr-only">Toggle Sidebar</span>
+</Button>

--- a/frontend-sv/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/frontend-sv/src/lib/components/ui/sidebar/sidebar.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import * as Sheet from "$lib/components/ui/sheet/index.js";
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { SIDEBAR_WIDTH_MOBILE } from "./constants.js";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		side = "left",
+		variant = "sidebar",
+		collapsible = "offcanvas",
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		side?: "left" | "right";
+		variant?: "sidebar" | "floating" | "inset";
+		collapsible?: "offcanvas" | "icon" | "none";
+	} = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+{#if collapsible === "none"}
+	<div
+		class={cn(
+			"bg-sidebar text-sidebar-foreground flex h-full w-[var(--sidebar-width)] flex-col",
+			className
+		)}
+		bind:this={ref}
+		{...restProps}
+	>
+		{@render children?.()}
+	</div>
+{:else if sidebar.isMobile}
+	<Sheet.Root
+		bind:open={() => sidebar.openMobile, (v) => sidebar.setOpenMobile(v)}
+		{...restProps}
+	>
+		<Sheet.Content
+			data-sidebar="sidebar"
+			data-mobile="true"
+			class="bg-sidebar text-sidebar-foreground w-[var(--sidebar-width)] p-0 [&>button]:hidden"
+			style="--sidebar-width: {SIDEBAR_WIDTH_MOBILE};"
+			{side}
+		>
+			<div class="flex h-full w-full flex-col">
+				{@render children?.()}
+			</div>
+		</Sheet.Content>
+	</Sheet.Root>
+{:else}
+	<div
+		bind:this={ref}
+		class="text-sidebar-foreground group peer hidden md:block"
+		data-state={sidebar.state}
+		data-collapsible={sidebar.state === "collapsed" ? collapsible : ""}
+		data-variant={variant}
+		data-side={side}
+	>
+		<!-- This is what handles the sidebar gap on desktop -->
+		<div
+			class={cn(
+				"relative h-svh w-[var(--sidebar-width)] bg-transparent transition-[width] duration-200 ease-linear",
+				"group-data-[collapsible=offcanvas]:w-0",
+				"group-data-[side=right]:rotate-180",
+				variant === "floating" || variant === "inset"
+					? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
+					: "group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)]"
+			)}
+		></div>
+		<div
+			class={cn(
+				"fixed inset-y-0 z-10 hidden h-svh w-[var(--sidebar-width)] transition-[left,right,width] duration-200 ease-linear md:flex",
+				side === "left"
+					? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+					: "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+				// Adjust the padding for floating and inset variants.
+				variant === "floating" || variant === "inset"
+					? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
+					: "group-data-[collapsible=icon]:w-[var(--sidebar-width-icon)] group-data-[side=left]:border-r group-data-[side=right]:border-l",
+				className
+			)}
+			{...restProps}
+		>
+			<div
+				data-sidebar="sidebar"
+				class="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow"
+			>
+				{@render children?.()}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/frontend-sv/src/lib/components/ui/tooltip/index.ts
+++ b/frontend-sv/src/lib/components/ui/tooltip/index.ts
@@ -1,0 +1,18 @@
+import { Tooltip as TooltipPrimitive } from "bits-ui";
+import Content from "./tooltip-content.svelte";
+
+const Root = TooltipPrimitive.Root;
+const Trigger = TooltipPrimitive.Trigger;
+const Provider = TooltipPrimitive.Provider;
+
+export {
+	Root,
+	Trigger,
+	Content,
+	Provider,
+	//
+	Root as Tooltip,
+	Content as TooltipContent,
+	Trigger as TooltipTrigger,
+	Provider as TooltipProvider,
+};

--- a/frontend-sv/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/frontend-sv/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 4,
+		...restProps
+	}: TooltipPrimitive.ContentProps = $props();
+</script>
+
+<TooltipPrimitive.Content
+	bind:ref
+	{sideOffset}
+	class={cn(
+		"bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs",
+		className
+	)}
+	{...restProps}
+/>

--- a/frontend-sv/src/lib/hooks/is-mobile.svelte.ts
+++ b/frontend-sv/src/lib/hooks/is-mobile.svelte.ts
@@ -1,0 +1,9 @@
+import { MediaQuery } from "svelte/reactivity";
+
+const MOBILE_BREAKPOINT = 768;
+
+export class IsMobile extends MediaQuery {
+	constructor() {
+		super(`max-width: ${MOBILE_BREAKPOINT - 1}px`);
+	}
+}

--- a/frontend-sv/src/lib/schemas/startup-schema.ts
+++ b/frontend-sv/src/lib/schemas/startup-schema.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+export const startupSchema = z.object({
+  name: z.string().min(2, "Startup name must be at least 2 characters"),
+  description: z.string().min(50, "Description must be at least 50 characters"),
+  industry: z.string().min(1, "Please select an industry"),
+  location: z.string().min(1, "Please enter a location"),
+  fundingStage: z.string().min(1, "Please select a funding stage"),
+  foundedYear: z.number().min(1900, "Please enter a valid year"),
+  teamSize: z.number().min(1, "Please enter team size"),
+  website: z.string().url("Please enter a valid website URL"),
+  teamMembers: z.array(z.object({
+    name: z.string().min(1, "Name is required"),
+    role: z.string().min(1, "Role is required"),
+    bio: z.string().min(1, "Bio is required"),
+    linkedin: z.string().url("Please enter a valid LinkedIn URL").optional()
+  })).optional(),
+  funding: z.object({
+    total: z.string().min(1, "Please enter total funding"),
+    lastRound: z.string().min(1, "Please enter last round"),
+    investors: z.string().min(1, "Please enter investors")
+  }),
+  metrics: z.object({
+    revenue: z.string().min(1, "Please enter revenue"),
+    growth: z.string().min(1, "Please enter growth"),
+    customers: z.string().min(1, "Please enter number of customers")
+  }),
+  socialMedia: z.object({
+    twitter: z.string().url("Please enter a valid Twitter URL").optional(),
+    linkedin: z.string().url("Please enter a valid LinkedIn URL").optional(),
+    facebook: z.string().url("Please enter a valid Facebook URL").optional(),
+    instagram: z.string().url("Please enter a valid Instagram URL").optional()
+  }).optional(),
+  contact: z.object({
+    email: z.string().email("Please enter a valid email address"),
+    phone: z.string().optional(),
+    address: z.string().optional()
+  }),
+  businessModel: z.string().min(1, "Please describe your business model"),
+  targetMarket: z.string().min(1, "Please describe your target market"),
+  competitors: z.string().min(1, "Please list your main competitors"),
+  traction: z.object({
+    users: z.string().optional(),
+    revenue: z.string().optional(),
+    growth: z.string().optional(),
+    partnerships: z.string().optional()
+  }).optional(),
+  useOfFunds: z.object({
+    product: z.string().min(1, "Please describe product development plans"),
+    marketing: z.string().min(1, "Please describe marketing plans"),
+    operations: z.string().min(1, "Please describe operational plans"),
+    team: z.string().min(1, "Please describe team expansion plans"),
+    other: z.string().optional()
+  }),
+  timeline: z.object({
+    past: z.array(z.object({
+      date: z.string().min(1, "Date is required"),
+      title: z.string().min(1, "Title is required"),
+      description: z.string().min(1, "Description is required"),
+      type: z.enum(["achievement", "funding", "partnership", "product", "other"])
+    })).optional(),
+    future: z.array(z.object({
+      date: z.string().min(1, "Date is required"),
+      title: z.string().min(1, "Title is required"),
+      description: z.string().min(1, "Description is required"),
+      type: z.enum(["launch", "funding", "partnership", "product", "other"])
+    })).optional()
+  }).optional()
+});
+
+export type StartupSchema = typeof startupSchema; 

--- a/frontend-sv/src/routes/dashboard/+layout.svelte
+++ b/frontend-sv/src/routes/dashboard/+layout.svelte
@@ -1,10 +1,46 @@
 <script lang="ts">
-    import type { Snippet } from "svelte";
+    import * as Sidebar from "@/components/ui/sidebar";
+    import AppSidebar from "@/components/app-sidebar.svelte";
+    import * as Breadcrumb from "@/components/ui/breadcrumb";
+    import { Separator } from "@/components/ui/sidebar";
 
-    let { children }: { children: Snippet } = $props();
+    let { children } = $props();
 </script>
 
-<div>
-    Hello & Welcome
-    {@render children?.()}
-</div>
+<Sidebar.Provider>
+    <AppSidebar />
+    <Sidebar.Inset>
+        <header class="flex h-16 shrink-0 items-center gap-2">
+            <div class="flex items-center gap-2 px-4">
+                <Sidebar.Trigger class="-ml-1" />
+                <Separator orientation="vertical" class="mr-2 h-4" />
+                <Breadcrumb.Root>
+                    <Breadcrumb.List>
+                        <Breadcrumb.Item class="hidden md:block">
+                            <Breadcrumb.Link href="#"
+                                >Building Your Application</Breadcrumb.Link
+                            >
+                        </Breadcrumb.Item>
+                        <Breadcrumb.Separator class="hidden md:block" />
+                        <Breadcrumb.Item>
+                            <Breadcrumb.Page>Data Fetching</Breadcrumb.Page>
+                        </Breadcrumb.Item>
+                    </Breadcrumb.List>
+                </Breadcrumb.Root>
+            </div>
+        </header>
+        <main>
+            {@render children?.()}
+        </main>
+        <!-- <div class="flex flex-1 flex-col gap-4 p-4 pt-0">
+            <div class="grid auto-rows-min gap-4 md:grid-cols-3">
+                <div class="bg-muted/50 aspect-video rounded-xl"></div>
+                <div class="bg-muted/50 aspect-video rounded-xl"></div>
+                <div class="bg-muted/50 aspect-video rounded-xl"></div>
+            </div>
+            <div
+                class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"
+            ></div>
+        </div> -->
+    </Sidebar.Inset>
+</Sidebar.Provider>

--- a/frontend-sv/src/routes/dashboard/-layout.svelte
+++ b/frontend-sv/src/routes/dashboard/-layout.svelte
@@ -1,0 +1,357 @@
+<script lang="ts">
+    import { page } from "$app/state";
+    import { Button } from "@/components/ui/button";
+    import * as DropdownMenu from "@/components/ui/dropdown-menu";
+    import { Input } from "@/components/ui/input";
+    import { Separator } from "@/components/ui/separator";
+    import { cn } from "@/utils";
+
+    // Import Lucide icons
+    import Home from "@lucide/svelte/icons/home";
+    import Search from "@lucide/svelte/icons/search";
+    import Bell from "@lucide/svelte/icons/bell";
+    import Users from "@lucide/svelte/icons/users";
+    import DollarSign from "@lucide/svelte/icons/dollar-sign";
+    import FileText from "@lucide/svelte/icons/file-text";
+    import Settings from "@lucide/svelte/icons/settings";
+    import MessageSquare from "@lucide/svelte/icons/message-square";
+    import LogOut from "@lucide/svelte/icons/log-out";
+    import Building from "@lucide/svelte/icons/building";
+    import User from "@lucide/svelte/icons/user";
+    import Moon from "@lucide/svelte/icons/moon";
+    import Sun from "@lucide/svelte/icons/sun";
+    import Menu from "@lucide/svelte/icons/menu";
+    import PanelLeft from "@lucide/svelte/icons/panel-left";
+    import type { Snippet } from "svelte";
+
+    // State variables
+    let { children }: { children: Snippet } = $props();
+    let sidebarOpen = $state(true);
+    let searchQuery = $state("");
+    let mobileNavOpen = $state(false);
+    let theme = $state("light");
+
+    // Get the current route and user type
+    let currentRoute = $derived(page.url.pathname);
+    let userType = $derived(
+        currentRoute.includes("/founder") ? "founder" : "investor",
+    );
+
+    // Navigation items
+    const founderNavItems = [
+        {
+            label: "Dashboard",
+            href: "/dashboard/founder",
+            icon: Home,
+            active: (path: string) => path === "/dashboard/founder",
+        },
+        {
+            label: "Startups",
+            href: "/dashboard/founder/startups",
+            icon: Building,
+            active: (path: string) =>
+                path.includes("/dashboard/founder/startups"),
+        },
+        {
+            label: "Messages",
+            href: "/dashboard/founder/messages",
+            icon: MessageSquare,
+            active: (path: string) =>
+                path.includes("/dashboard/founder/messages"),
+        },
+        {
+            label: "Settings",
+            href: "/dashboard/founder/settings",
+            icon: Settings,
+            active: (path: string) =>
+                path.includes("/dashboard/founder/settings"),
+        },
+    ];
+
+    const investorNavItems = [
+        {
+            label: "Dashboard",
+            href: "/dashboard/investor",
+            icon: Home,
+            active: (path: string) => path === "/dashboard/investor",
+        },
+        {
+            label: "Startups",
+            href: "/dashboard/investor/startups",
+            icon: Building,
+            active: (path: string) =>
+                path.includes("/dashboard/investor/startups"),
+        },
+        {
+            label: "Messages",
+            href: "/dashboard/investor/messages",
+            icon: MessageSquare,
+            active: (path: string) =>
+                path.includes("/dashboard/investor/messages"),
+        },
+        {
+            label: "Settings",
+            href: "/dashboard/investor/settings",
+            icon: Settings,
+            active: (path: string) =>
+                path.includes("/dashboard/investor/settings"),
+        },
+    ];
+
+    // Toggle sidebar
+    function toggleSidebar() {
+        sidebarOpen = !sidebarOpen;
+    }
+
+    // Toggle theme
+    function toggleTheme() {
+        theme = theme === "light" ? "dark" : "light";
+        document.documentElement.classList.toggle("dark");
+    }
+
+    // Mock user data
+    const user = {
+        name: userType === "founder" ? "Jane Founder" : "John Investor",
+        email:
+            userType === "founder" ? "jane@startup.com" : "john@investor.com",
+        avatar: `https://ui-avatars.com/api/?name=${userType === "founder" ? "Jane+Founder" : "John+Investor"}&background=random`,
+    };
+
+    // Get the appropriate navigation items
+    let navItems = $derived(
+        userType === "founder" ? founderNavItems : investorNavItems,
+    );
+</script>
+
+<div class="flex min-h-screen bg-background">
+    <!-- Sidebar -->
+    <div
+        class={cn(
+            "fixed left-0 top-0 z-20 flex h-full w-64 flex-col border-r bg-card transition-all duration-300",
+            sidebarOpen ? "translate-x-0" : "-translate-x-full",
+        )}
+    >
+        <!-- Sidebar header -->
+        <div class="flex h-16 items-center border-b px-4">
+            <!-- <a href="/" class="flex items-center gap-2 font-semibold">
+                <div
+                    class="h-8 w-8 rounded-md bg-primary text-primary-foreground grid place-items-center font-bold"
+                >
+                    <img
+                        src="/logo.svg"
+                        alt="Startup Connect Logo"
+                        class="h-6 w-6"
+                    />
+                </div>
+                <span> Startup Connect</span>
+            </a> -->
+
+            <div class="mr-4 flex items-center">
+                <a href="/" class="flex items-center space-x-2">
+                    <img src="/logo.svg" alt="Logo" class="h-6 w-6" />
+                    <span class="font-bold">Startup Connect</span>
+                </a>
+            </div>
+        </div>
+
+        <!-- Sidebar navigation -->
+        <nav class="flex-1 space-y-1 px-2 py-4">
+            {#each navItems as item}
+                <a
+                    href={item.href}
+                    class={cn(
+                        "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                        item.active(currentRoute)
+                            ? "bg-primary/10 text-primary"
+                            : "hover:bg-muted text-muted-foreground hover:text-foreground",
+                    )}
+                >
+                    <item.icon class="h-4 w-4" />
+                    <span>{item.label}</span>
+                </a>
+            {/each}
+        </nav>
+
+        <!-- Sidebar footer -->
+        <div class="mt-auto border-t p-4">
+            <div class="flex items-center gap-3">
+                <img
+                    src={user.avatar}
+                    alt={user.name}
+                    class="h-9 w-9 rounded-full object-cover"
+                />
+                <div class="flex-1 truncate">
+                    <p class="text-sm font-medium">{user.name}</p>
+                    <p class="truncate text-xs text-muted-foreground">
+                        {user.email}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Main content -->
+    <div
+        class={cn(
+            "flex flex-1 flex-col transition-all duration-300",
+            sidebarOpen ? "pl-64" : "pl-0",
+        )}
+    >
+        <!-- Header -->
+        <header
+            class="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background px-4 md:px-6"
+        >
+            <Button
+                variant="ghost"
+                size="icon"
+                onclick={toggleSidebar}
+                class="mr-2 h-9 w-9"
+            >
+                <!-- <Menu class="h-5 w-5" /> -->
+                <PanelLeft class="h-5 w-5" />
+                <span class="sr-only">Toggle sidebar</span>
+            </Button>
+
+            <!-- Search -->
+            <div class="relative flex-1 max-w-md">
+                <Search
+                    class="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground"
+                />
+                <Input
+                    type="search"
+                    placeholder="Search..."
+                    class="w-full pl-8 bg-background"
+                    bind:value={searchQuery}
+                />
+            </div>
+
+            <!-- Desktop navigation -->
+            <nav class="hidden md:flex items-center gap-4 flex-1 justify-end">
+                <Button variant="ghost" size="icon" class="relative">
+                    <Bell class="h-5 w-5" />
+                    <span
+                        class="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary"
+                    ></span>
+                    <span class="sr-only">Notifications</span>
+                </Button>
+
+                <Button variant="ghost" size="icon" onclick={toggleTheme}>
+                    {#if theme === "light"}
+                        <Moon class="h-5 w-5" />
+                        <span class="sr-only">Dark mode</span>
+                    {:else}
+                        <Sun class="h-5 w-5" />
+                        <span class="sr-only">Light mode</span>
+                    {/if}
+                </Button>
+
+                <DropdownMenu.Root>
+                    <DropdownMenu.Trigger>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            class="rounded-full"
+                        >
+                            <img
+                                src={user.avatar}
+                                alt={user.name}
+                                class="h-8 w-8 rounded-full object-cover"
+                            />
+                            <span class="sr-only">User menu</span>
+                        </Button>
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Content class="w-56" align="end">
+                        <div class="flex items-center gap-3 p-3">
+                            <img
+                                src={user.avatar}
+                                alt={user.name}
+                                class="h-9 w-9 rounded-full object-cover"
+                            />
+                            <div class="flex-1 truncate">
+                                <p class="text-sm font-medium">{user.name}</p>
+                                <p
+                                    class="truncate text-xs text-muted-foreground"
+                                >
+                                    {user.email}
+                                </p>
+                            </div>
+                        </div>
+                        <DropdownMenu.Separator />
+                        <DropdownMenu.Item>
+                            <User class="mr-2 h-4 w-4" />
+                            <span>Profile</span>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item>
+                            <Settings class="mr-2 h-4 w-4" />
+                            <span>Settings</span>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Separator />
+                        <DropdownMenu.Item>
+                            <LogOut class="mr-2 h-4 w-4" />
+                            <span>Log out</span>
+                        </DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                </DropdownMenu.Root>
+            </nav>
+
+            <!-- Mobile menu button (visible on smaller screens) -->
+            <div class="flex items-center md:hidden gap-4">
+                <Button variant="ghost" size="icon">
+                    <Bell class="h-5 w-5" />
+                </Button>
+                <DropdownMenu.Root>
+                    <DropdownMenu.Trigger>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            class="rounded-full"
+                        >
+                            <img
+                                src={user.avatar}
+                                alt={user.name}
+                                class="h-8 w-8 rounded-full object-cover"
+                            />
+                            <span class="sr-only">User menu</span>
+                        </Button>
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Content class="w-56" align="end">
+                        <div class="flex items-center gap-3 p-3">
+                            <img
+                                src={user.avatar}
+                                alt={user.name}
+                                class="h-9 w-9 rounded-full object-cover"
+                            />
+                            <div class="flex-1 truncate">
+                                <p class="text-sm font-medium">{user.name}</p>
+                                <p
+                                    class="truncate text-xs text-muted-foreground"
+                                >
+                                    {user.email}
+                                </p>
+                            </div>
+                        </div>
+                        <DropdownMenu.Separator />
+                        <DropdownMenu.Item>
+                            <User class="mr-2 h-4 w-4" />
+                            <span>Profile</span>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item>
+                            <Settings class="mr-2 h-4 w-4" />
+                            <span>Settings</span>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Separator />
+                        <DropdownMenu.Item>
+                            <LogOut class="mr-2 h-4 w-4" />
+                            <span>Log out</span>
+                        </DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                </DropdownMenu.Root>
+            </div>
+        </header>
+
+        <!-- Page content -->
+        <main class="flex-1 p-4 md:p-6 overflow-auto">
+            {@render children()}
+        </main>
+    </div>
+</div>

--- a/frontend-sv/src/routes/dashboard/founder/+page.svelte
+++ b/frontend-sv/src/routes/dashboard/founder/+page.svelte
@@ -1,1 +1,1026 @@
-<div>I am a founder</div>
+<script lang="ts">
+    import { onMount } from "svelte";
+    import * as Card from "$lib/components/ui/card";
+    import { Progress } from "$lib/components/ui/progress";
+    import { Button } from "$lib/components/ui/button";
+    import { Separator } from "$lib/components/ui/separator";
+    import * as Tabs from "$lib/components/ui/tabs";
+    import * as Avatar from "$lib/components/ui/avatar";
+    import { Badge } from "$lib/components/ui/badge";
+    import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+    import * as Tooltip from "$lib/components/ui/tooltip";
+    import TrendingUp from "@lucide/svelte/icons/trending-up";
+    import TrendingDown from "@lucide/svelte/icons/trending-down";
+    import Users from "@lucide/svelte/icons/users";
+    import Calendar from "@lucide/svelte/icons/calendar";
+    import Wallet from "@lucide/svelte/icons/wallet";
+    import ClipboardCheck from "@lucide/svelte/icons/clipboard-check";
+    import MessageSquare from "@lucide/svelte/icons/message-square";
+    import FileText from "@lucide/svelte/icons/file-text";
+    import Edit3 from "@lucide/svelte/icons/edit-3";
+    import MailOpen from "@lucide/svelte/icons/mail-open";
+    import DollarSign from "@lucide/svelte/icons/dollar-sign";
+    import CircleDollarSign from "@lucide/svelte/icons/circle-dollar-sign";
+    import BarChart from "@lucide/svelte/icons/bar-chart";
+    import LineChart from "@lucide/svelte/icons/line-chart";
+    import Bell from "@lucide/svelte/icons/bell";
+    import Clock from "@lucide/svelte/icons/clock";
+    import ArrowRight from "@lucide/svelte/icons/arrow-right";
+    import Target from "@lucide/svelte/icons/target";
+    import Settings from "@lucide/svelte/icons/settings";
+    import AlertCircle from "@lucide/svelte/icons/alert-circle";
+    import CheckCircle2 from "@lucide/svelte/icons/check-circle-2";
+    import Info from "@lucide/svelte/icons/info";
+    import Rocket from "@lucide/svelte/icons/rocket";
+    import LightbulbIcon from "@lucide/svelte/icons/lightbulb";
+    import Star from "@lucide/svelte/icons/star";
+    import Sparkles from "@lucide/svelte/icons/sparkles";
+
+    // Dashboard data (would normally come from the server via a load function)
+    const dashboardData = {
+        founder: {
+            name: "Alex Johnson",
+            avatar: "/images/avatar.jpg",
+            company: "NexTech Solutions",
+            lastLogin: "Today at 9:30 AM",
+            recentAchievement: "Completed pitch deck",
+        },
+        fundraising: {
+            current: 2500000,
+            goal: 5000000,
+            investors: 12,
+            percentComplete: 50,
+            recentInvestments: [
+                { name: "Tech Ventures", amount: 500000, date: "2023-10-15" },
+                { name: "Angel Group B", amount: 250000, date: "2023-10-01" },
+                { name: "SV Capital", amount: 750000, date: "2023-09-20" },
+            ],
+            nextMilestone: { name: "Series A Close", target: "2023-12-15" },
+        },
+        metrics: {
+            monthlyRevenue: {
+                value: 45200,
+                percentChange: 12,
+                changeText: "+$5.2K from last month",
+                history: [32000, 35000, 34000, 38000, 40000, 45200],
+            },
+            activeUsers: {
+                value: 2350,
+                percentChange: 18,
+                changeText: "+350 new users this month",
+                history: [1200, 1500, 1800, 1950, 2100, 2350],
+            },
+            investorInterest: {
+                value: 24,
+                percentChange: 8,
+                changeText: "Profile views this week",
+                history: [10, 14, 18, 16, 22, 24],
+            },
+            runway: {
+                value: 14,
+                unit: "months",
+                detail: "At current burn rate",
+                history: [18, 17, 16, 15, 14.5, 14],
+            },
+            customerAcquisition: {
+                value: 850,
+                cost: 42,
+                changePercent: -5,
+                detail: "Cost per acquisition down 5%",
+            },
+            churnRate: {
+                value: 3.2,
+                unit: "%",
+                changePercent: -0.8,
+                detail: "Improved by 0.8% vs last month",
+            },
+        },
+        dueDisgience: {
+            documentsUploaded: 15,
+            totalDocuments: 20,
+            nextDue: "Financial Projections",
+            dueDate: "2023-10-30",
+        },
+        investorRelations: {
+            activeConversations: 8,
+            pendingResponses: 3,
+            meetings: {
+                scheduled: 4,
+                next: {
+                    investor: "VC Partners",
+                    date: "Oct 28, 2023",
+                    time: "11:00 AM",
+                },
+            },
+            potentialInvestors: [
+                { name: "Sequoia Capital", status: "Interested", level: 4 },
+                { name: "Y Combinator", status: "Evaluating", level: 3 },
+                {
+                    name: "Andreessen Horowitz",
+                    status: "First Contact",
+                    level: 2,
+                },
+            ],
+        },
+        recentActivity: [
+            {
+                type: "investment_interest",
+                source: "Tech Ventures Capital",
+                timeAgo: "10 minutes ago",
+                priority: "high",
+            },
+            {
+                type: "document_review",
+                source: "SV Angel",
+                timeAgo: "2 hours ago",
+                priority: "medium",
+            },
+            {
+                type: "message",
+                source: "Jane Smith (Investor)",
+                timeAgo: "Yesterday",
+                priority: "medium",
+            },
+            {
+                type: "milestone",
+                source: "1000 users reached",
+                timeAgo: "3 days ago",
+                priority: "low",
+            },
+        ],
+        tasks: [
+            {
+                id: 1,
+                title: "Update financial projections",
+                dueDate: "2023-10-28",
+                completed: false,
+                priority: "high",
+            },
+            {
+                id: 2,
+                title: "Prepare for investor meeting",
+                dueDate: "2023-10-30",
+                completed: false,
+                priority: "high",
+            },
+            {
+                id: 3,
+                title: "Review legal documents",
+                dueDate: "2023-11-05",
+                completed: false,
+                priority: "medium",
+            },
+            {
+                id: 4,
+                title: "Update pitch deck",
+                dueDate: "2023-10-20",
+                completed: true,
+                priority: "medium",
+            },
+        ],
+        insights: [
+            "Your active user growth is outperforming 80% of similar startups",
+            "Consider increasing your fundraising goal based on current investor interest",
+            "Your runway should be extended to at least 18 months to attract Series A investors",
+        ],
+    };
+
+    // State variables
+    let activeTab = $state("overview");
+    let showAllMetrics = $state(false);
+    let isLoading = $state(true);
+    let chartData = $state<any>(null);
+
+    // Format currency for display
+    function formatCurrency(amount: number, abbreviate = false): string {
+        if (abbreviate) {
+            if (amount >= 1000000) {
+                return `$${(amount / 1000000).toFixed(1)}M`;
+            } else if (amount >= 1000) {
+                return `$${(amount / 1000).toFixed(1)}K`;
+            }
+        }
+
+        return new Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: "USD",
+            maximumFractionDigits: 0,
+        }).format(amount);
+    }
+
+    // Format date to "Month Day, Year" format
+    function formatDate(dateString: string): string {
+        const date = new Date(dateString);
+        return new Intl.DateTimeFormat("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+        }).format(date);
+    }
+
+    // Format date to relative time (e.g., "2 days ago")
+    function getRelativeTime(dateString: string): string {
+        const date = new Date(dateString);
+        const now = new Date();
+        const diffMs = now.getTime() - date.getTime();
+        const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+        if (diffDays === 0) return "Today";
+        if (diffDays === 1) return "Yesterday";
+        if (diffDays < 7) return `${diffDays} days ago`;
+        if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+
+        return formatDate(dateString);
+    }
+
+    // Get priority badge class based on priority level
+    function getPriorityClass(priority: string): string {
+        switch (priority) {
+            case "high":
+                return "bg-red-500/10 text-red-500 dark:bg-red-500/20";
+            case "medium":
+                return "bg-amber-500/10 text-amber-500 dark:bg-amber-500/20";
+            case "low":
+                return "bg-green-500/10 text-green-500 dark:bg-green-500/20";
+            default:
+                return "bg-blue-500/10 text-blue-500 dark:bg-blue-500/20";
+        }
+    }
+
+    // Simulate loading the chart data
+    onMount(() => {
+        // Simulate an API call
+        setTimeout(() => {
+            chartData = {
+                revenue: dashboardData.metrics.monthlyRevenue.history,
+                users: dashboardData.metrics.activeUsers.history,
+                interest: dashboardData.metrics.investorInterest.history,
+                labels: ["May", "Jun", "Jul", "Aug", "Sep", "Oct"],
+            };
+
+            isLoading = false;
+        }, 800);
+    });
+
+    // Generate sparkline SVG path from history data
+    function generateSparkline(
+        data: number[],
+        height: number = 30,
+        width: number = 100,
+    ): string {
+        if (!data || data.length < 2) return "";
+
+        const max = Math.max(...data);
+        const min = Math.min(...data);
+        const range = max - min || 1;
+
+        // Scale values to fit the height
+        const scaledValues = data.map(
+            (val) => height - ((val - min) / range) * height,
+        );
+
+        // Calculate x increment
+        const xIncrement = width / (data.length - 1);
+
+        // Generate path
+        let path = `M0,${scaledValues[0]}`;
+        scaledValues.forEach((val, i) => {
+            if (i > 0) {
+                path += ` L${i * xIncrement},${val}`;
+            }
+        });
+
+        return path;
+    }
+
+    // Get color based on trend (positive/negative)
+    function getTrendColor(value: number): string {
+        return value >= 0 ? "text-green-500" : "text-red-500";
+    }
+
+    // Get icon based on trend
+    function getTrendIcon(value: number) {
+        return value >= 0 ? TrendingUp : TrendingDown;
+    }
+
+    // Count incomplete high priority tasks
+    let incompletePriorityTasks = $derived(
+        dashboardData.tasks.filter((t) => !t.completed && t.priority === "high")
+            .length,
+    );
+</script>
+
+<div class="container max-w-7xl py-6 space-y-8">
+    <!-- Dashboard Header with Welcome Message -->
+    <div
+        class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 animate-in slide-in-from-top-5 duration-500"
+    >
+        <div>
+            <h1 class="text-3xl font-bold tracking-tight">
+                Welcome back, {dashboardData.founder.name}
+            </h1>
+            <p class="text-muted-foreground mt-1 flex items-center gap-2">
+                <Clock class="h-4 w-4" />
+                <span>Last login: {dashboardData.founder.lastLogin}</span>
+
+                {#if dashboardData.founder.recentAchievement}
+                    <Badge
+                        variant="secondary"
+                        class="ml-2 bg-green-500/10 text-green-500 dark:bg-green-500/20"
+                    >
+                        <CheckCircle2 class="h-3 w-3 mr-1" />
+                        {dashboardData.founder.recentAchievement}
+                    </Badge>
+                {/if}
+            </p>
+        </div>
+
+        <div class="flex items-center gap-3">
+            {#if incompletePriorityTasks > 0}
+                <Badge
+                    variant="outline"
+                    class="bg-red-500/10 text-red-500 dark:bg-red-500/20 flex items-center"
+                >
+                    <AlertCircle class="h-3.5 w-3.5 mr-1.5" />
+                    {incompletePriorityTasks} high priority tasks
+                </Badge>
+            {/if}
+
+            <Button variant="outline" size="sm" class="gap-2">
+                <Bell class="h-4 w-4" />
+                <span>Notifications</span>
+                {#if dashboardData.recentActivity.length > 0}
+                    <Badge
+                        class="ml-1 h-5 w-5 p-0 flex items-center justify-center"
+                        >{dashboardData.recentActivity.length}</Badge
+                    >
+                {/if}
+            </Button>
+
+            <Button variant="outline" size="sm" class="gap-2">
+                <Settings class="h-4 w-4" />
+                <span>Settings</span>
+            </Button>
+        </div>
+    </div>
+
+    <!-- Tabs Navigation -->
+    <Tabs.Root
+        value={activeTab}
+        onValueChange={(val) => (activeTab = val)}
+        class="mt-8 animate-in fade-in-50 duration-700 delay-200"
+    >
+        <Tabs.List class="bg-background border-b mb-6">
+            <Tabs.Trigger
+                value="overview"
+                class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2"
+            >
+                Overview
+            </Tabs.Trigger>
+            <Tabs.Trigger
+                value="fundraising"
+                class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2"
+            >
+                Fundraising
+            </Tabs.Trigger>
+            <Tabs.Trigger
+                value="metrics"
+                class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2"
+            >
+                Metrics
+            </Tabs.Trigger>
+            <Tabs.Trigger
+                value="investors"
+                class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2"
+            >
+                Investors
+            </Tabs.Trigger>
+            <Tabs.Trigger
+                value="tasks"
+                class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2"
+            >
+                Tasks
+            </Tabs.Trigger>
+        </Tabs.List>
+
+        <!-- Overview Tab -->
+        <Tabs.Content
+            value="overview"
+            class="space-y-8 animate-in slide-in-from-bottom-5 duration-500"
+        >
+            <!-- Fundraising Progress Card (Highlight) -->
+            <div
+                class="bg-black/90 rounded-lg p-6 text-white border border-white/10 shadow-xl overflow-hidden relative"
+            >
+                <!-- Glowing gradient background effect -->
+                <div
+                    class="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-purple-500/5 to-pink-500/10 opacity-50"
+                ></div>
+
+                <div class="relative">
+                    <div
+                        class="flex flex-col md:flex-row justify-between items-start md:items-center mb-5"
+                    >
+                        <div>
+                            <h2
+                                class="text-xl font-bold flex items-center gap-2"
+                            >
+                                <Rocket class="h-5 w-5 text-blue-400" />
+                                Fundraising Progress
+                            </h2>
+                            <p class="text-white/70 mt-1">
+                                Track your fundraising journey
+                            </p>
+                        </div>
+                        <div class="text-right md:mt-0 mt-3">
+                            <div class="text-3xl font-bold">
+                                {formatCurrency(
+                                    dashboardData.fundraising.current,
+                                    true,
+                                )}
+                            </div>
+                            <p
+                                class="text-white/70 flex items-center gap-1 justify-end"
+                            >
+                                <Target class="h-4 w-4 text-blue-400" />
+                                <span
+                                    >of {formatCurrency(
+                                        dashboardData.fundraising.goal,
+                                        true,
+                                    )} goal</span
+                                >
+                            </p>
+                        </div>
+                    </div>
+
+                    <div
+                        class="relative h-3 bg-white/10 rounded-full overflow-hidden mb-3 backdrop-blur-sm"
+                    >
+                        <div
+                            class="absolute left-0 top-0 h-full bg-gradient-to-r from-blue-400 to-indigo-500"
+                            style:width="{dashboardData.fundraising
+                                .percentComplete}%"
+                        >
+                            <div
+                                class="absolute top-0 left-0 w-full h-full bg-[url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiPjxyZWN0IGZpbGw9InJnYmEoMjU1LDI1NSwyNTUsMC4yKSIgd2lkdGg9IjIiIGhlaWdodD0iMiIvPjwvc3ZnPg==')]"
+                            ></div>
+                        </div>
+                        <!-- Animated dot following progress -->
+                        <div
+                            class="absolute -top-1.5 h-6 w-6 rounded-full bg-white shadow-[0_0_10px_rgba(255,255,255,0.5)] transform-gpu transition-all duration-1000"
+                            style:left="calc({dashboardData.fundraising
+                                .percentComplete}% - 12px)"
+                        ></div>
+                    </div>
+
+                    <div class="flex flex-wrap justify-between mt-4 gap-2">
+                        <div
+                            class="text-sm bg-white/10 px-3 py-2 rounded-full backdrop-blur-sm"
+                        >
+                            <span class="text-white/70 mr-1">Investors:</span>
+                            <span class="font-semibold"
+                                >{dashboardData.fundraising.investors}</span
+                            >
+                        </div>
+                        <div
+                            class="text-sm bg-white/10 px-3 py-2 rounded-full backdrop-blur-sm"
+                        >
+                            <span class="text-white/70 mr-1">Progress:</span>
+                            <span class="font-semibold"
+                                >{dashboardData.fundraising
+                                    .percentComplete}%</span
+                            >
+                        </div>
+                        <div
+                            class="text-sm bg-white/10 px-3 py-2 rounded-full backdrop-blur-sm"
+                        >
+                            <span class="text-white/70 mr-1"
+                                >Next milestone:</span
+                            >
+                            <span class="font-semibold"
+                                >{dashboardData.fundraising.nextMilestone
+                                    .name}</span
+                            >
+                        </div>
+                    </div>
+
+                    <div class="mt-6 flex justify-end">
+                        <Button
+                            variant="default"
+                            size="sm"
+                            class="bg-white/20 hover:bg-white/30 backdrop-blur-sm border-0 text-white"
+                        >
+                            <ArrowRight class="mr-2 h-4 w-4" />
+                            View Fundraising Details
+                        </Button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Key Metrics Row -->
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <!-- Monthly Revenue Card -->
+                <Card.Root class="overflow-hidden">
+                    <div
+                        class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10"
+                    >
+                        <h3
+                            class="font-medium text-white/70 flex items-center gap-2"
+                        >
+                            <DollarSign class="h-4 w-4 text-green-400" />
+                            Monthly Revenue
+                        </h3>
+                        <div class="flex flex-col gap-1 mt-3">
+                            <div class="flex items-center gap-2">
+                                <span class="text-3xl font-bold"
+                                    >{formatCurrency(
+                                        dashboardData.metrics.monthlyRevenue
+                                            .value,
+                                        true,
+                                    )}</span
+                                >
+                                <span
+                                    class="flex items-center text-sm font-medium text-green-400"
+                                >
+                                    <TrendingUp class="inline h-4 w-4 mr-1" />
+                                    {dashboardData.metrics.monthlyRevenue
+                                        .percentChange}%
+                                </span>
+                            </div>
+                            <p class="text-sm text-white/70">
+                                {dashboardData.metrics.monthlyRevenue
+                                    .changeText}
+                            </p>
+
+                            <!-- Sparkline visualization -->
+                            <div class="mt-2 h-[30px] relative">
+                                {#if chartData}
+                                    <svg class="w-full h-full overflow-visible">
+                                        <path
+                                            d={generateSparkline(
+                                                chartData.revenue,
+                                                30,
+                                                150,
+                                            )}
+                                            fill="none"
+                                            stroke="rgba(74, 222, 128, 0.5)"
+                                            stroke-width="2"
+                                            stroke-linecap="round"
+                                        />
+                                        <!-- Highlight the last point -->
+                                        <circle
+                                            cx={150}
+                                            cy={30 -
+                                                ((chartData.revenue[
+                                                    chartData.revenue.length - 1
+                                                ] -
+                                                    Math.min(
+                                                        ...chartData.revenue,
+                                                    )) /
+                                                    (Math.max(
+                                                        ...chartData.revenue,
+                                                    ) -
+                                                        Math.min(
+                                                            ...chartData.revenue,
+                                                        ))) *
+                                                    30}
+                                            r="3"
+                                            fill="#4ADE80"
+                                        />
+                                    </svg>
+                                {:else}
+                                    <div
+                                        class="animate-pulse w-full h-[30px] bg-white/5 rounded"
+                                    ></div>
+                                {/if}
+                            </div>
+                        </div>
+                    </div>
+                </Card.Root>
+
+                <!-- Active Users Card -->
+                <Card.Root class="overflow-hidden">
+                    <div
+                        class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10"
+                    >
+                        <h3
+                            class="font-medium text-white/70 flex items-center gap-2"
+                        >
+                            <Users class="h-4 w-4 text-blue-400" />
+                            Active Users
+                        </h3>
+                        <div class="flex flex-col gap-1 mt-3">
+                            <div class="flex items-center gap-2">
+                                <span class="text-3xl font-bold"
+                                    >{dashboardData.metrics.activeUsers.value.toLocaleString()}</span
+                                >
+                                <span
+                                    class="flex items-center text-sm font-medium text-green-400"
+                                >
+                                    <TrendingUp class="inline h-4 w-4 mr-1" />
+                                    {dashboardData.metrics.activeUsers
+                                        .percentChange}%
+                                </span>
+                            </div>
+                            <p class="text-sm text-white/70">
+                                {dashboardData.metrics.activeUsers.changeText}
+                            </p>
+
+                            <!-- Sparkline visualization -->
+                            <div class="mt-2 h-[30px] relative">
+                                {#if chartData}
+                                    <svg class="w-full h-full overflow-visible">
+                                        <path
+                                            d={generateSparkline(
+                                                chartData.users,
+                                                30,
+                                                150,
+                                            )}
+                                            fill="none"
+                                            stroke="rgba(96, 165, 250, 0.5)"
+                                            stroke-width="2"
+                                            stroke-linecap="round"
+                                        />
+                                        <!-- Highlight the last point -->
+                                        <circle
+                                            cx={150}
+                                            cy={30 -
+                                                ((chartData.users[
+                                                    chartData.users.length - 1
+                                                ] -
+                                                    Math.min(
+                                                        ...chartData.users,
+                                                    )) /
+                                                    (Math.max(
+                                                        ...chartData.users,
+                                                    ) -
+                                                        Math.min(
+                                                            ...chartData.users,
+                                                        ))) *
+                                                    30}
+                                            r="3"
+                                            fill="#60A5FA"
+                                        />
+                                    </svg>
+                                {:else}
+                                    <div
+                                        class="animate-pulse w-full h-[30px] bg-white/5 rounded"
+                                    ></div>
+                                {/if}
+                            </div>
+                        </div>
+                    </div>
+                </Card.Root>
+
+                <!-- Investor Interest Card -->
+                <Card.Root class="overflow-hidden">
+                    <div
+                        class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10"
+                    >
+                        <h3
+                            class="font-medium text-white/70 flex items-center gap-2"
+                        >
+                            <Star class="h-4 w-4 text-amber-400" />
+                            Investor Interest
+                        </h3>
+                        <div class="flex flex-col gap-1 mt-3">
+                            <div class="flex items-center gap-2">
+                                <span class="text-3xl font-bold"
+                                    >{dashboardData.metrics.investorInterest
+                                        .value}</span
+                                >
+                                <span
+                                    class="flex items-center text-sm font-medium text-green-400"
+                                >
+                                    <TrendingUp class="inline h-4 w-4 mr-1" />
+                                    {dashboardData.metrics.investorInterest
+                                        .percentChange}%
+                                </span>
+                            </div>
+                            <p class="text-sm text-white/70">
+                                {dashboardData.metrics.investorInterest
+                                    .changeText}
+                            </p>
+
+                            <!-- Sparkline visualization -->
+                            <div class="mt-2 h-[30px] relative">
+                                {#if chartData}
+                                    <svg class="w-full h-full overflow-visible">
+                                        <path
+                                            d={generateSparkline(
+                                                chartData.interest,
+                                                30,
+                                                150,
+                                            )}
+                                            fill="none"
+                                            stroke="rgba(251, 191, 36, 0.5)"
+                                            stroke-width="2"
+                                            stroke-linecap="round"
+                                        />
+                                        <!-- Highlight the last point -->
+                                        <circle
+                                            cx={150}
+                                            cy={30 -
+                                                ((chartData.interest[
+                                                    chartData.interest.length -
+                                                        1
+                                                ] -
+                                                    Math.min(
+                                                        ...chartData.interest,
+                                                    )) /
+                                                    (Math.max(
+                                                        ...chartData.interest,
+                                                    ) -
+                                                        Math.min(
+                                                            ...chartData.interest,
+                                                        ))) *
+                                                    30}
+                                            r="3"
+                                            fill="#FBBF24"
+                                        />
+                                    </svg>
+                                {:else}
+                                    <div
+                                        class="animate-pulse w-full h-[30px] bg-white/5 rounded"
+                                    ></div>
+                                {/if}
+                            </div>
+                        </div>
+                    </div>
+                </Card.Root>
+
+                <!-- Runway Card -->
+                <Card.Root class="overflow-hidden">
+                    <div
+                        class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10"
+                    >
+                        <h3
+                            class="font-medium text-white/70 flex items-center gap-2"
+                        >
+                            <Calendar class="h-4 w-4 text-purple-400" />
+                            Runway
+                        </h3>
+                        <div class="flex flex-col gap-1 mt-3">
+                            <div class="flex items-center gap-2">
+                                <span class="text-3xl font-bold"
+                                    >{dashboardData.metrics.runway.value}</span
+                                >
+                                <span class="text-xl"
+                                    >{dashboardData.metrics.runway.unit}</span
+                                >
+                            </div>
+                            <p class="text-sm text-white/70">
+                                {dashboardData.metrics.runway.detail}
+                            </p>
+
+                            <!-- Warning badge if runway is less than 12 months -->
+                            {#if dashboardData.metrics.runway.value < 12}
+                                <Badge
+                                    variant="secondary"
+                                    class="mt-2 bg-amber-500/20 text-amber-400 self-start"
+                                >
+                                    <AlertCircle class="h-3 w-3 mr-1" />
+                                    Consider extending runway
+                                </Badge>
+                            {/if}
+                        </div>
+                    </div>
+                </Card.Root>
+            </div>
+
+            <!-- Management Cards Row -->
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <!-- Startup Profile Card -->
+                <Card.Root class="overflow-hidden">
+                    <div
+                        class="bg-gradient-to-br from-black/90 to-black/95 text-white p-6 h-full border border-white/10"
+                    >
+                        <h2
+                            class="text-lg font-semibold mb-2 flex items-center gap-2"
+                        >
+                            <Rocket class="h-4 w-4 text-blue-400" />
+                            Startup Profile
+                        </h2>
+                        <p class="text-white/70 mb-6">
+                            Create or update your startup profile to attract
+                            investors
+                        </p>
+
+                        <!-- Completion indicator -->
+                        <div class="mb-6">
+                            <div class="flex justify-between mb-2">
+                                <span class="text-sm">Profile Completeness</span
+                                >
+                                <span class="text-sm">85%</span>
+                            </div>
+                            <div
+                                class="relative h-2 bg-white/10 rounded-full overflow-hidden"
+                            >
+                                <div
+                                    class="absolute left-0 top-0 h-full bg-gradient-to-r from-blue-400 to-indigo-500"
+                                    style="width: 85%"
+                                ></div>
+                            </div>
+                        </div>
+
+                        <Button
+                            variant="outline"
+                            class="w-full bg-white/5 border-white/20 text-white hover:bg-white/10"
+                            href="/dashboard/founder/startup"
+                        >
+                            <Edit3 class="mr-2 h-4 w-4" />
+                            Manage Profile
+                        </Button>
+                    </div>
+                </Card.Root>
+
+                <!-- Investor Relations Card -->
+                <Card.Root class="overflow-hidden">
+                    <div
+                        class="bg-gradient-to-br from-black/90 to-black/95 text-white p-6 h-full border border-white/10"
+                    >
+                        <h2
+                            class="text-lg font-semibold mb-2 flex items-center gap-2"
+                        >
+                            <MessageSquare class="h-4 w-4 text-blue-400" />
+                            Investor Relations
+                        </h2>
+                        <p class="text-white/70 mb-4">
+                            Manage communications and track investor engagement
+                        </p>
+
+                        <div class="space-y-4 mb-6">
+                            <div class="flex justify-between items-center">
+                                <div class="flex items-center">
+                                    <MessageSquare
+                                        class="mr-2 h-4 w-4 text-white/70"
+                                    />
+                                    <span class="text-sm"
+                                        >Active Conversations</span
+                                    >
+                                </div>
+                                <span class="font-medium"
+                                    >{dashboardData.investorRelations
+                                        .activeConversations}</span
+                                >
+                            </div>
+
+                            <div class="flex justify-between items-center">
+                                <div class="flex items-center">
+                                    <MailOpen
+                                        class="mr-2 h-4 w-4 text-white/70"
+                                    />
+                                    <span class="text-sm"
+                                        >Pending Responses</span
+                                    >
+                                </div>
+                                <span class="font-medium"
+                                    >{dashboardData.investorRelations
+                                        .pendingResponses}</span
+                                >
+                            </div>
+
+                            {#if dashboardData.investorRelations.meetings?.next}
+                                <div class="mt-4 p-3 bg-white/10 rounded-md">
+                                    <p class="text-sm font-medium">
+                                        Next Meeting
+                                    </p>
+                                    <div
+                                        class="flex items-center mt-1 justify-between"
+                                    >
+                                        <span class="text-sm text-white/70"
+                                            >{dashboardData.investorRelations
+                                                .meetings.next.investor}</span
+                                        >
+                                        <span
+                                            class="text-xs bg-blue-500/20 text-blue-400 px-2 py-0.5 rounded-full"
+                                            >{dashboardData.investorRelations
+                                                .meetings.next.date}</span
+                                        >
+                                    </div>
+                                </div>
+                            {/if}
+                        </div>
+
+                        <Button
+                            variant="outline"
+                            class="w-full bg-white/5 border-white/20 text-white hover:bg-white/10"
+                        >
+                            <MessageSquare class="mr-2 h-4 w-4" />
+                            View Messages
+                        </Button>
+                    </div>
+                </Card.Root>
+
+                <!-- Due Diligence Card -->
+                <Card.Root class="overflow-hidden">
+                    <div
+                        class="bg-gradient-to-br from-black/90 to-black/95 text-white p-6 h-full border border-white/10"
+                    >
+                        <h2
+                            class="text-lg font-semibold mb-2 flex items-center gap-2"
+                        >
+                            <FileText class="h-4 w-4 text-blue-400" />
+                            Due Diligence
+                        </h2>
+                        <p class="text-white/70 mb-4">
+                            Track and manage investor due diligence requests
+                        </p>
+
+                        <div class="mb-6">
+                            <div class="flex justify-between mb-2">
+                                <span class="text-sm">Documents Uploaded</span>
+                                <span class="text-sm"
+                                    >{dashboardData.dueDisgience
+                                        .documentsUploaded}/{dashboardData
+                                        .dueDisgience.totalDocuments}</span
+                                >
+                            </div>
+                            <div
+                                class="relative h-2 bg-white/10 rounded-full overflow-hidden"
+                            >
+                                <div
+                                    class="absolute left-0 top-0 h-full bg-gradient-to-r from-blue-400 to-indigo-500"
+                                    style="width: {(dashboardData.dueDisgience
+                                        .documentsUploaded /
+                                        dashboardData.dueDisgience
+                                            .totalDocuments) *
+                                        100}%"
+                                ></div>
+                            </div>
+
+                            {#if dashboardData.dueDisgience.nextDue}
+                                <div class="mt-4 p-3 bg-white/10 rounded-md">
+                                    <p class="text-sm font-medium">
+                                        Next Document Due
+                                    </p>
+                                    <div
+                                        class="flex items-center mt-1 justify-between"
+                                    >
+                                        <span class="text-sm text-white/70"
+                                            >{dashboardData.dueDisgience
+                                                .nextDue}</span
+                                        >
+                                        <span
+                                            class="text-xs bg-amber-500/20 text-amber-400 px-2 py-0.5 rounded-full"
+                                            >{dashboardData.dueDisgience
+                                                .dueDate}</span
+                                        >
+                                    </div>
+                                </div>
+                            {/if}
+                        </div>
+
+                        <Button
+                            variant="outline"
+                            class="w-full bg-white/5 border-white/20 text-white hover:bg-white/10"
+                        >
+                            <FileText class="mr-2 h-4 w-4" />
+                            Manage Documents
+                        </Button>
+                    </div>
+                </Card.Root>
+            </div>
+        </Tabs.Content>
+    </Tabs.Root>
+</div>
+
+<style>
+    /* Additional styles for visual fidelity */
+    :global(.bg-black\/90) {
+        background-color: rgba(18, 18, 18, 0.98);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    /* Gradient animation for the progress bar highlight */
+    @keyframes shimmer {
+        0% {
+            transform: translateX(-100%);
+        }
+        100% {
+            transform: translateX(100%);
+        }
+    }
+
+    /* Subtle card hover effect */
+    :global(.card-hover) {
+        transition: all 0.2s ease;
+    }
+
+    :global(.card-hover:hover) {
+        transform: translateY(-3px);
+        box-shadow:
+            0 10px 15px -3px rgba(0, 0, 0, 0.1),
+            0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    }
+
+    /* Hide scrollbars for certain elements */
+    .hide-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+
+    .hide-scrollbar {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+</style>

--- a/frontend-sv/src/routes/dashboard/founder/+page.svelte.fixed
+++ b/frontend-sv/src/routes/dashboard/founder/+page.svelte.fixed
@@ -1,0 +1,619 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as Card from "$lib/components/ui/card";
+  import { Progress } from "$lib/components/ui/progress";
+  import { Button } from "$lib/components/ui/button";
+  import { Separator } from "$lib/components/ui/separator";
+  import * as Tabs from "$lib/components/ui/tabs";
+  import * as Avatar from "$lib/components/ui/avatar";
+  import { Badge } from "$lib/components/ui/badge";
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+  import * as Tooltip from "$lib/components/ui/tooltip";
+  import TrendingUp from "@lucide/svelte/icons/trending-up";
+  import TrendingDown from "@lucide/svelte/icons/trending-down";
+  import Users from "@lucide/svelte/icons/users";
+  import Calendar from "@lucide/svelte/icons/calendar";
+  import Wallet from "@lucide/svelte/icons/wallet";
+  import ClipboardCheck from "@lucide/svelte/icons/clipboard-check";
+  import MessageSquare from "@lucide/svelte/icons/message-square";
+  import FileText from "@lucide/svelte/icons/file-text";
+  import Edit3 from "@lucide/svelte/icons/edit-3";
+  import MailOpen from "@lucide/svelte/icons/mail-open";
+  import DollarSign from "@lucide/svelte/icons/dollar-sign";
+  import CircleDollarSign from "@lucide/svelte/icons/circle-dollar-sign";
+  import BarChart from "@lucide/svelte/icons/bar-chart";
+  import LineChart from "@lucide/svelte/icons/line-chart";
+  import Bell from "@lucide/svelte/icons/bell";
+  import Clock from "@lucide/svelte/icons/clock";
+  import ArrowRight from "@lucide/svelte/icons/arrow-right";
+  import Target from "@lucide/svelte/icons/target";
+  import Settings from "@lucide/svelte/icons/settings";
+  import AlertCircle from "@lucide/svelte/icons/alert-circle";
+  import CheckCircle2 from "@lucide/svelte/icons/check-circle-2";
+  import Info from "@lucide/svelte/icons/info";
+  import Rocket from "@lucide/svelte/icons/rocket";
+  import LightbulbIcon from "@lucide/svelte/icons/lightbulb";
+  import Star from "@lucide/svelte/icons/star";
+  import Sparkles from "@lucide/svelte/icons/sparkles";
+
+  // Dashboard data (would normally come from the server via a load function)
+  const dashboardData = {
+    founder: {
+      name: "Alex Johnson",
+      avatar: "/images/avatar.jpg",
+      company: "NexTech Solutions",
+      lastLogin: "Today at 9:30 AM",
+      recentAchievement: "Completed pitch deck"
+    },
+    fundraising: {
+      current: 2500000,
+      goal: 5000000,
+      investors: 12,
+      percentComplete: 50,
+      recentInvestments: [
+        { name: "Tech Ventures", amount: 500000, date: "2023-10-15" },
+        { name: "Angel Group B", amount: 250000, date: "2023-10-01" },
+        { name: "SV Capital", amount: 750000, date: "2023-09-20" }
+      ],
+      nextMilestone: { name: "Series A Close", target: "2023-12-15" }
+    },
+    metrics: {
+      monthlyRevenue: {
+        value: 45200,
+        percentChange: 12,
+        changeText: "+$5.2K from last month",
+        history: [32000, 35000, 34000, 38000, 40000, 45200]
+      },
+      activeUsers: {
+        value: 2350,
+        percentChange: 18,
+        changeText: "+350 new users this month",
+        history: [1200, 1500, 1800, 1950, 2100, 2350]
+      },
+      investorInterest: {
+        value: 24,
+        percentChange: 8,
+        changeText: "Profile views this week",
+        history: [10, 14, 18, 16, 22, 24]
+      },
+      runway: {
+        value: 14,
+        unit: "months",
+        detail: "At current burn rate",
+        history: [18, 17, 16, 15, 14.5, 14]
+      },
+      customerAcquisition: {
+        value: 850,
+        cost: 42,
+        changePercent: -5,
+        detail: "Cost per acquisition down 5%"
+      },
+      churnRate: {
+        value: 3.2,
+        unit: "%",
+        changePercent: -0.8,
+        detail: "Improved by 0.8% vs last month"
+      }
+    },
+    dueDisgience: {
+      documentsUploaded: 15,
+      totalDocuments: 20,
+      nextDue: "Financial Projections",
+      dueDate: "2023-10-30"
+    },
+    investorRelations: {
+      activeConversations: 8,
+      pendingResponses: 3,
+      meetings: {
+        scheduled: 4,
+        next: { investor: "VC Partners", date: "Oct 28, 2023", time: "11:00 AM" }
+      },
+      potentialInvestors: [
+        { name: "Sequoia Capital", status: "Interested", level: 4 },
+        { name: "Y Combinator", status: "Evaluating", level: 3 },
+        { name: "Andreessen Horowitz", status: "First Contact", level: 2 }
+      ]
+    },
+    recentActivity: [
+      {
+        type: "investment_interest",
+        source: "Tech Ventures Capital",
+        timeAgo: "10 minutes ago",
+        priority: "high"
+      },
+      {
+        type: "document_review",
+        source: "SV Angel",
+        timeAgo: "2 hours ago",
+        priority: "medium"
+      },
+      {
+        type: "message",
+        source: "Jane Smith (Investor)",
+        timeAgo: "Yesterday",
+        priority: "medium"
+      },
+      {
+        type: "milestone",
+        source: "1000 users reached",
+        timeAgo: "3 days ago",
+        priority: "low"
+      }
+    ],
+    tasks: [
+      { id: 1, title: "Update financial projections", dueDate: "2023-10-28", completed: false, priority: "high" },
+      { id: 2, title: "Prepare for investor meeting", dueDate: "2023-10-30", completed: false, priority: "high" },
+      { id: 3, title: "Review legal documents", dueDate: "2023-11-05", completed: false, priority: "medium" },
+      { id: 4, title: "Update pitch deck", dueDate: "2023-10-20", completed: true, priority: "medium" }
+    ],
+    insights: [
+      "Your active user growth is outperforming 80% of similar startups",
+      "Consider increasing your fundraising goal based on current investor interest",
+      "Your runway should be extended to at least 18 months to attract Series A investors"
+    ]
+  };
+
+  // State variables
+  let activeTab = $state("overview");
+  let showAllMetrics = $state(false);
+  let isLoading = $state(true);
+  let chartData = $state<any>(null);
+  
+  // Format currency for display
+  function formatCurrency(amount: number, abbreviate = false): string {
+    if (abbreviate) {
+      if (amount >= 1000000) {
+        return `$${(amount / 1000000).toFixed(1)}M`;
+      } else if (amount >= 1000) {
+        return `$${(amount / 1000).toFixed(1)}K`;
+      }
+    }
+
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(amount);
+  }
+  
+  // Format date to "Month Day, Year" format
+  function formatDate(dateString: string): string {
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat('en-US', { 
+      month: 'short', 
+      day: 'numeric', 
+      year: 'numeric' 
+    }).format(date);
+  }
+  
+  // Format date to relative time (e.g., "2 days ago")
+  function getRelativeTime(dateString: string): string {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    
+    if (diffDays === 0) return "Today";
+    if (diffDays === 1) return "Yesterday";
+    if (diffDays < 7) return `${diffDays} days ago`;
+    if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+    
+    return formatDate(dateString);
+  }
+  
+  // Get priority badge class based on priority level
+  function getPriorityClass(priority: string): string {
+    switch(priority) {
+      case "high": return "bg-red-500/10 text-red-500 dark:bg-red-500/20";
+      case "medium": return "bg-amber-500/10 text-amber-500 dark:bg-amber-500/20";
+      case "low": return "bg-green-500/10 text-green-500 dark:bg-green-500/20";
+      default: return "bg-blue-500/10 text-blue-500 dark:bg-blue-500/20";
+    }
+  }
+  
+  // Simulate loading the chart data
+  onMount(() => {
+    // Simulate an API call
+    setTimeout(() => {
+      chartData = {
+        revenue: dashboardData.metrics.monthlyRevenue.history,
+        users: dashboardData.metrics.activeUsers.history,
+        interest: dashboardData.metrics.investorInterest.history,
+        labels: ['May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct']
+      };
+      
+      isLoading = false;
+    }, 800);
+  });
+  
+  // Generate sparkline SVG path from history data
+  function generateSparkline(data: number[], height: number = 30, width: number = 100): string {
+    if (!data || data.length < 2) return '';
+    
+    const max = Math.max(...data);
+    const min = Math.min(...data);
+    const range = max - min || 1;
+    
+    // Scale values to fit the height
+    const scaledValues = data.map(val => height - ((val - min) / range * height));
+    
+    // Calculate x increment
+    const xIncrement = width / (data.length - 1);
+    
+    // Generate path
+    let path = `M0,${scaledValues[0]}`;
+    scaledValues.forEach((val, i) => {
+      if (i > 0) {
+        path += ` L${i * xIncrement},${val}`;
+      }
+    });
+    
+    return path;
+  }
+  
+  // Get color based on trend (positive/negative)
+  function getTrendColor(value: number): string {
+    return value >= 0 ? 'text-green-500' : 'text-red-500';
+  }
+  
+  // Get icon based on trend
+  function getTrendIcon(value: number) {
+    return value >= 0 ? TrendingUp : TrendingDown;
+  }
+  
+  // Count incomplete high priority tasks
+  let incompletePriorityTasks = $derived(dashboardData.tasks.filter(t => !t.completed && t.priority === 'high').length);
+</script>
+
+<div class="container max-w-7xl py-6 space-y-8">
+  <!-- Dashboard Header with Welcome Message -->
+  <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 animate-in slide-in-from-top-5 duration-500">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight">Welcome back, {dashboardData.founder.name}</h1>
+      <p class="text-muted-foreground mt-1 flex items-center gap-2">
+        <Clock class="h-4 w-4" />
+        <span>Last login: {dashboardData.founder.lastLogin}</span>
+        
+        {#if dashboardData.founder.recentAchievement}
+          <Badge variant="secondary" class="ml-2 bg-green-500/10 text-green-500 dark:bg-green-500/20">
+            <CheckCircle2 class="h-3 w-3 mr-1" />
+            {dashboardData.founder.recentAchievement}
+          </Badge>
+        {/if}
+      </p>
+    </div>
+    
+    <div class="flex items-center gap-3">
+      {#if incompletePriorityTasks > 0}
+        <Badge variant="outline" class="bg-red-500/10 text-red-500 dark:bg-red-500/20 flex items-center">
+          <AlertCircle class="h-3.5 w-3.5 mr-1.5" />
+          {incompletePriorityTasks} high priority tasks
+        </Badge>
+      {/if}
+      
+      <Button variant="outline" size="sm" class="gap-2">
+        <Bell class="h-4 w-4" />
+        <span>Notifications</span>
+        {#if dashboardData.recentActivity.length > 0}
+          <Badge class="ml-1 h-5 w-5 p-0 flex items-center justify-center">{dashboardData.recentActivity.length}</Badge>
+        {/if}
+      </Button>
+      
+      <Button variant="outline" size="sm" class="gap-2">
+        <Settings class="h-4 w-4" />
+        <span>Settings</span>
+      </Button>
+    </div>
+  </div>
+
+  <!-- Tabs Navigation -->
+  <Tabs.Root value={activeTab} onValueChange={(val) => activeTab = val} class="mt-8 animate-in fade-in-50 duration-700 delay-200">
+    <Tabs.List class="bg-background border-b mb-6">
+      <Tabs.Trigger value="overview" class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2">
+        Overview
+      </Tabs.Trigger>
+      <Tabs.Trigger value="fundraising" class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2">
+        Fundraising
+      </Tabs.Trigger>
+      <Tabs.Trigger value="metrics" class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2">
+        Metrics
+      </Tabs.Trigger>
+      <Tabs.Trigger value="investors" class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2">
+        Investors
+      </Tabs.Trigger>
+      <Tabs.Trigger value="tasks" class="text-sm data-[state=active]:border-primary data-[state=active]:border-b-2">
+        Tasks
+      </Tabs.Trigger>
+    </Tabs.List>
+  </Tabs.Root>
+
+  <!-- Overview Tab -->
+  <Tabs.Content value="overview" class="space-y-8 animate-in slide-in-from-bottom-5 duration-500">
+    <!-- Fundraising Progress Card (Highlight) -->
+    <div class="bg-black/90 rounded-lg p-6 text-white border border-white/10 shadow-xl overflow-hidden relative">
+      <!-- Glowing gradient background effect -->
+      <div class="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-purple-500/5 to-pink-500/10 opacity-50"></div>
+      
+      <div class="relative">
+        <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-5">
+          <div>
+            <h2 class="text-xl font-bold flex items-center gap-2">
+              <Rocket class="h-5 w-5 text-blue-400" /> 
+              Fundraising Progress
+            </h2>
+            <p class="text-white/70 mt-1">Track your fundraising journey</p>
+          </div>
+          <div class="text-right md:mt-0 mt-3">
+            <div class="text-3xl font-bold">
+              {formatCurrency(dashboardData.fundraising.current, true)}
+            </div>
+            <p class="text-white/70 flex items-center gap-1 justify-end">
+              <Target class="h-4 w-4 text-blue-400" />
+              <span>of {formatCurrency(dashboardData.fundraising.goal, true)} goal</span>
+            </p>
+          </div>
+        </div>
+  
+        <div class="relative h-3 bg-white/10 rounded-full overflow-hidden mb-3 backdrop-blur-sm">
+          <div
+            class="absolute left-0 top-0 h-full bg-gradient-to-r from-blue-400 to-indigo-500"
+            style:width="{dashboardData.fundraising.percentComplete}%"
+          >
+            <div class="absolute top-0 left-0 w-full h-full bg-[url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiPjxyZWN0IGZpbGw9InJnYmEoMjU1LDI1NSwyNTUsMC4yKSIgd2lkdGg9IjIiIGhlaWdodD0iMiIvPjwvc3ZnPg==')]"></div>
+          </div>
+          <!-- Animated dot following progress -->
+          <div 
+            class="absolute -top-1.5 h-6 w-6 rounded-full bg-white shadow-[0_0_10px_rgba(255,255,255,0.5)] transform-gpu transition-all duration-1000"
+            style:left="calc({dashboardData.fundraising.percentComplete}% - 12px)"
+          ></div>
+        </div>
+  
+        <div class="flex flex-wrap justify-between mt-4 gap-2">
+          <div class="text-sm bg-white/10 px-3 py-2 rounded-full backdrop-blur-sm">
+            <span class="text-white/70 mr-1">Investors:</span>
+            <span class="font-semibold">{dashboardData.fundraising.investors}</span>
+          </div>
+          <div class="text-sm bg-white/10 px-3 py-2 rounded-full backdrop-blur-sm">
+            <span class="text-white/70 mr-1">Progress:</span>
+            <span class="font-semibold">{dashboardData.fundraising.percentComplete}%</span>
+          </div>
+          <div class="text-sm bg-white/10 px-3 py-2 rounded-full backdrop-blur-sm">
+            <span class="text-white/70 mr-1">Next milestone:</span>
+            <span class="font-semibold">{dashboardData.fundraising.nextMilestone.name}</span>
+          </div>
+        </div>
+        
+        <div class="mt-6 flex justify-end">
+          <Button variant="default" size="sm" class="bg-white/20 hover:bg-white/30 backdrop-blur-sm border-0 text-white">
+            <ArrowRight class="mr-2 h-4 w-4" />
+            View Fundraising Details
+          </Button>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Key Metrics Row -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <!-- Monthly Revenue Card -->
+      <Card.Root class="overflow-hidden">
+        <div class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10">
+          <h3 class="font-medium text-white/70 flex items-center gap-2">
+            <DollarSign class="h-4 w-4 text-green-400" />
+            Monthly Revenue
+          </h3>
+          <div class="flex flex-col gap-1 mt-3">
+            <div class="flex items-center gap-2">
+              <span class="text-3xl font-bold">{formatCurrency(dashboardData.metrics.monthlyRevenue.value, true)}</span>
+              <span class="flex items-center text-sm font-medium text-green-400">
+                <TrendingUp class="inline h-4 w-4 mr-1" />
+                {dashboardData.metrics.monthlyRevenue.percentChange}%
+              </span>
+            </div>
+            <p class="text-sm text-white/70">
+              {dashboardData.metrics.monthlyRevenue.changeText}
+            </p>
+            
+            <!-- Sparkline visualization -->
+            <div class="mt-2 h-[30px] relative">
+              {#if chartData}
+                <svg class="w-full h-full overflow-visible">
+                  <path 
+                    d={generateSparkline(chartData.revenue, 30, 150)} 
+                    fill="none" 
+                    stroke="rgba(74, 222, 128, 0.5)" 
+                    stroke-width="2"
+                    stroke-linecap="round" 
+                  />
+                  <!-- Highlight the last point -->
+                  <circle
+                    cx={150}
+                    cy={30 - ((chartData.revenue[chartData.revenue.length-1] - Math.min(...chartData.revenue)) / (Math.max(...chartData.revenue) - Math.min(...chartData.revenue)) * 30)}
+                    r="3"
+                    fill="#4ADE80"
+                  />
+                </svg>
+              {:else}
+                <div class="animate-pulse w-full h-[30px] bg-white/5 rounded"></div>
+              {/if}
+            </div>
+          </div>
+        </div>
+      </Card.Root>
+  
+      <!-- Active Users Card -->
+      <Card.Root class="overflow-hidden">
+        <div class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10">
+          <h3 class="font-medium text-white/70 flex items-center gap-2">
+            <Users class="h-4 w-4 text-blue-400" />
+            Active Users
+          </h3>
+          <div class="flex flex-col gap-1 mt-3">
+            <div class="flex items-center gap-2">
+              <span class="text-3xl font-bold">{dashboardData.metrics.activeUsers.value.toLocaleString()}</span>
+              <span class="flex items-center text-sm font-medium text-green-400">
+                <TrendingUp class="inline h-4 w-4 mr-1" />
+                {dashboardData.metrics.activeUsers.percentChange}%
+              </span>
+            </div>
+            <p class="text-sm text-white/70">
+              {dashboardData.metrics.activeUsers.changeText}
+            </p>
+            
+            <!-- Sparkline visualization -->
+            <div class="mt-2 h-[30px] relative">
+              {#if chartData}
+                <svg class="w-full h-full overflow-visible">
+                  <path 
+                    d={generateSparkline(chartData.users, 30, 150)} 
+                    fill="none" 
+                    stroke="rgba(96, 165, 250, 0.5)" 
+                    stroke-width="2"
+                    stroke-linecap="round" 
+                  />
+                  <!-- Highlight the last point -->
+                  <circle
+                    cx={150}
+                    cy={30 - ((chartData.users[chartData.users.length-1] - Math.min(...chartData.users)) / (Math.max(...chartData.users) - Math.min(...chartData.users)) * 30)}
+                    r="3"
+                    fill="#60A5FA"
+                  />
+                </svg>
+              {:else}
+                <div class="animate-pulse w-full h-[30px] bg-white/5 rounded"></div>
+              {/if}
+            </div>
+          </div>
+        </div>
+      </Card.Root>
+  
+      <!-- Investor Interest Card -->
+      <Card.Root class="overflow-hidden">
+        <div class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10">
+          <h3 class="font-medium text-white/70 flex items-center gap-2">
+            <Star class="h-4 w-4 text-amber-400" />
+            Investor Interest
+          </h3>
+          <div class="flex flex-col gap-1 mt-3">
+            <div class="flex items-center gap-2">
+              <span class="text-3xl font-bold">{dashboardData.metrics.investorInterest.value}</span>
+              <span class="flex items-center text-sm font-medium text-green-400">
+                <TrendingUp class="inline h-4 w-4 mr-1" />
+                {dashboardData.metrics.investorInterest.percentChange}%
+              </span>
+            </div>
+            <p class="text-sm text-white/70">
+              {dashboardData.metrics.investorInterest.changeText}
+            </p>
+            
+            <!-- Sparkline visualization -->
+            <div class="mt-2 h-[30px] relative">
+              {#if chartData}
+                <svg class="w-full h-full overflow-visible">
+                  <path 
+                    d={generateSparkline(chartData.interest, 30, 150)} 
+                    fill="none" 
+                    stroke="rgba(251, 191, 36, 0.5)" 
+                    stroke-width="2"
+                    stroke-linecap="round" 
+                  />
+                  <!-- Highlight the last point -->
+                  <circle
+                    cx={150}
+                    cy={30 - ((chartData.interest[chartData.interest.length-1] - Math.min(...chartData.interest)) / (Math.max(...chartData.interest) - Math.min(...chartData.interest)) * 30)}
+                    r="3"
+                    fill="#FBBF24"
+                  />
+                </svg>
+              {:else}
+                <div class="animate-pulse w-full h-[30px] bg-white/5 rounded"></div>
+              {/if}
+            </div>
+          </div>
+        </div>
+      </Card.Root>
+  
+      <!-- Runway Card -->
+      <Card.Root class="overflow-hidden">
+        <div class="bg-gradient-to-br from-black/90 to-black/95 text-white p-5 h-full border border-white/10">
+          <h3 class="font-medium text-white/70 flex items-center gap-2">
+            <Calendar class="h-4 w-4 text-purple-400" />
+            Runway
+          </h3>
+          <div class="flex flex-col gap-1 mt-3">
+            <div class="flex items-center gap-2">
+              <span class="text-3xl font-bold">{dashboardData.metrics.runway.value}</span>
+              <span class="text-xl">{dashboardData.metrics.runway.unit}</span>
+            </div>
+            <p class="text-sm text-white/70">
+              {dashboardData.metrics.runway.detail}
+            </p>
+            
+            <!-- Warning badge if runway is less than 12 months -->
+            {#if dashboardData.metrics.runway.value < 12}
+              <Badge variant="secondary" class="mt-2 bg-amber-500/20 text-amber-400 self-start">
+                <AlertCircle class="h-3 w-3 mr-1" />
+                Consider extending runway
+              </Badge>
+            {/if}
+          </div>
+        </div>
+      </Card.Root>
+    </div>
+    
+    <!-- Management Cards Row -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <!-- Startup Profile Card -->
+      <Card.Root class="overflow-hidden">
+        <div class="bg-gradient-to-br from-black/90 to-black/95 text-white p-6 h-full border border-white/10">
+          <h2 class="text-lg font-semibold mb-2 flex items-center gap-2">
+            <Rocket class="h-4 w-4 text-blue-400" />
+            Startup Profile
+          </h2>
+          <p class="text-white/70 mb-6">
+            Create or update your startup profile to attract investors
+          </p>
+          
+          <!-- Completion indicator -->
+          <div class="mb-6">
+            <div class="flex justify-between mb-2">
+              <span class="text-sm">Profile Completeness</span>
+              <span class="text-sm">85%</span>
+            </div>
+            <div class="relative h-2 bg-white/10 rounded-full overflow-hidden">
+              <div class="absolute left-0 top-0 h-full bg-gradient-to-r from-blue-400 to-indigo-500" style="width: 85%"></div>
+            </div>
+          </div>
+          
+          <Button
+            variant="outline"
+            class="w-full bg-white/5 border-white/20 text-white hover:bg-white/10"
+            href="/dashboard/founder/startup"
+          >
+            <Edit3 class="mr-2 h-4 w-4" />
+            Manage Profile
+          </Button>
+        </div>
+      </Card.Root>
+  
+      <!-- Investor Relations Card -->
+      <Card.Root class="overflow-hidden">
+        <div class="bg-gradient-to-br from-black/90 to-black/95 text-white p-6 h-full border border-white/10">
+          <h2 class="text-lg font-semibold mb-2 flex items-center gap-2">
+            <MessageSquare class="h-4 w-4 text-blue-400" />
+            Investor Relations
+          </h2>
+          <p class="text-white/70 mb-4">
+            Manage communications and track investor engagement
+          </p>
+  
+          <div class="space-y-4 mb-6">
+            <div class="flex justify-between items-center">
+              <div class="flex items-center">
+                <MessageSquare class="mr-2 h-4 w-4 text-white/70" />
+                <span class="text-sm">Active Conversations</span>
+              </div>
+              <span class="font-medium">{dashboardData.investorRelations.activeConversations}</span>
+            </div>
+  
+            <div class="flex justify-between items-center">
+              <div

--- a/frontend-sv/src/routes/dashboard/founder/startup/+page.svelte
+++ b/frontend-sv/src/routes/dashboard/founder/startup/+page.svelte
@@ -1,0 +1,858 @@
+<script lang="ts">
+    import { page } from "$app/stores";
+    import { Button } from "$lib/components/ui/button";
+    import { Input } from "$lib/components/ui/input";
+    import * as Select from "$lib/components/ui/select";
+    import { 
+        List,
+        Search,
+        AlertCircle,
+        FolderOpen,
+        LayoutGrid,
+        Plus,
+        RotateCw,
+        DollarSign,
+        Users,
+        FileEdit,
+        Rocket,
+        TrendingUp,
+        AlertTriangle
+    } from "@lucide/svelte/icons";
+    import * as Skeleton from "$lib/components/ui/skeleton";
+    import StartupCard from "$lib/components/StartupCard.svelte";
+    import StartupList from "$lib/components/StartupList.svelte";
+
+    // View mode state (persisted in localStorage if available)
+    let viewMode = $state<"grid" | "list">(
+        typeof localStorage !== "undefined" &&
+            localStorage.getItem("founderDashboardView")
+            ? (localStorage.getItem("founderDashboardView") as "grid" | "list")
+            : "grid",
+    );
+
+    // Save view mode preference
+    $effect(() => {
+        if (typeof localStorage !== "undefined") {
+            localStorage.setItem("founderDashboardView", viewMode);
+        }
+    });
+
+    // Filter options
+    let filterOptions = $state({
+        search: "",
+        industry: "all",
+        stage: "all",
+        sortBy: "newest",
+    });
+
+    // Industry options
+    const industryOptions = [
+        { label: "All Industries", value: "all" },
+        { label: "Fintech", value: "fintech" },
+        { label: "Healthcare", value: "healthcare" },
+        { label: "E-commerce", value: "ecommerce" },
+        { label: "SaaS", value: "saas" },
+        { label: "AI/ML", value: "ai-ml" },
+    ];
+
+    // Stage options
+    const stageOptions = [
+        { label: "All Stages", value: "all" },
+        { label: "Idea", value: "idea" },
+        { label: "MVP", value: "mvp" },
+        { label: "Seed", value: "seed" },
+        { label: "Series A", value: "series_a" },
+        { label: "Series B+", value: "series_b_plus" },
+    ];
+
+    // Sort options
+    const sortOptions = [
+        { label: "Newest First", value: "newest" },
+        { label: "Oldest First", value: "oldest" },
+        { label: "Most Funding", value: "funding" },
+        { label: "Name A-Z", value: "name_asc" },
+        { label: "Name Z-A", value: "name_desc" },
+    ];
+
+    // Mock data for startups (would be replaced with actual data loading)
+    let startups = $state<any[]>([
+        {
+            id: "1",
+            name: "TechFinance",
+            description:
+                "A revolutionary fintech platform that simplifies banking for SMEs.",
+            logo: "https://via.placeholder.com/150",
+            industry: "fintech",
+            stage: "seed",
+            location: "San Francisco, CA",
+            foundedDate: "2022-05-01",
+            lastUpdate: "2023-10-15",
+            fundingRaised: 750000,
+            fundingGoal: 1200000,
+            fundingProgress: 62,
+            team: 8,
+            featured: true,
+            metrics: {
+                revenue: 25000,
+                users: 1200,
+                growth: 15,
+            },
+            tasks: [
+                {
+                    id: 1,
+                    title: "Update financial projections",
+                    completed: false,
+                    dueDate: "2023-11-10",
+                },
+                {
+                    id: 2,
+                    title: "Prepare for investor meeting",
+                    completed: true,
+                    dueDate: "2023-10-30",
+                },
+            ],
+        },
+        {
+            id: "2",
+            name: "HealthAI",
+            description:
+                "AI-powered healthcare diagnostics for rural communities.",
+            logo: "https://via.placeholder.com/150",
+            industry: "healthcare",
+            stage: "series_a",
+            location: "Boston, MA",
+            foundedDate: "2021-03-15",
+            lastUpdate: "2023-10-05",
+            fundingRaised: 3500000,
+            fundingGoal: 5000000,
+            fundingProgress: 70,
+            team: 24,
+            featured: false,
+            metrics: {
+                revenue: 180000,
+                users: 45000,
+                growth: 24,
+            },
+            tasks: [
+                {
+                    id: 3,
+                    title: "Hire senior ML engineer",
+                    completed: false,
+                    dueDate: "2023-11-15",
+                },
+                {
+                    id: 4,
+                    title: "Submit FDA application",
+                    completed: false,
+                    dueDate: "2023-12-01",
+                },
+            ],
+        },
+        {
+            id: "3",
+            name: "EcoShop",
+            description:
+                "Sustainable e-commerce marketplace for eco-friendly products.",
+            logo: "https://via.placeholder.com/150",
+            industry: "ecommerce",
+            stage: "mvp",
+            location: "Portland, OR",
+            foundedDate: "2023-01-10",
+            lastUpdate: "2023-10-20",
+            fundingRaised: 250000,
+            fundingGoal: 500000,
+            fundingProgress: 50,
+            team: 5,
+            featured: false,
+            metrics: {
+                revenue: 12000,
+                users: 3500,
+                growth: 32,
+            },
+            tasks: [
+                {
+                    id: 5,
+                    title: "Launch mobile app beta",
+                    completed: false,
+                    dueDate: "2023-11-20",
+                },
+                {
+                    id: 6,
+                    title: "Onboard 10 new vendors",
+                    completed: true,
+                    dueDate: "2023-10-15",
+                },
+            ],
+        },
+    ]);
+
+    // Loading and error states
+    let loading = $state(false);
+    let error = $state<string | null>(null);
+
+    // Import missing icons
+    import Star from "@lucide/svelte/icons/star";
+    import Sparkles from "@lucide/svelte/icons/sparkles";
+
+    // Format currency
+    function formatCurrency(amount: number): string {
+        if (amount >= 1000000) {
+            return `$${(amount / 1000000).toFixed(1)}M`;
+        } else if (amount >= 1000) {
+            return `$${(amount / 1000).toFixed(0)}K`;
+        }
+        return `$${amount}`;
+    }
+    
+    // Function to get filtered startups
+    function getFilteredStartups() {
+        return startups
+            .filter((startup) => {
+                // Filter by search term
+                if (
+                    filterOptions.search &&
+                    !startup.name
+                        .toLowerCase()
+                        .includes(filterOptions.search.toLowerCase()) &&
+                    !startup.description
+                        .toLowerCase()
+                        .includes(filterOptions.search.toLowerCase())
+                ) {
+                    return false;
+                }
+
+                // Filter by industry
+                if (
+                    filterOptions.industry !== "all" &&
+                    startup.industry !== filterOptions.industry
+                ) {
+                    return false;
+                }
+
+                // Filter by stage
+                if (
+                    filterOptions.stage !== "all" &&
+                    startup.stage !== filterOptions.stage
+                ) {
+                    return false;
+                }
+
+                return true;
+            })
+            .sort((a, b) => {
+                // Sort based on selected option
+                switch (filterOptions.sortBy) {
+                    case "newest":
+                        return (
+                            new Date(b.foundedDate).getTime() -
+                            new Date(a.foundedDate).getTime()
+                        );
+                    case "oldest":
+                        return (
+                            new Date(a.foundedDate).getTime() -
+                            new Date(b.foundedDate).getTime()
+                        );
+                    case "funding":
+                        return b.fundingRaised - a.fundingRaised;
+                    case "name_asc":
+                        return a.name.localeCompare(b.name);
+                    case "name_desc":
+                        return b.name.localeCompare(a.name);
+                    default:
+                        return 0;
+                }
+            });
+    }
+
+    // Get filtered startups (reactive)
+    $effect(() => {
+        filteredStartups = getFilteredStartups();
+    });
+    let filteredStartups = $state<typeof startups>([]);
+
+    // Function to refresh data
+    function refreshData() {
+        loading = true;
+        error = null;
+
+        // Simulate API call
+        setTimeout(() => {
+            loading = false;
+            // Uncomment to test error state
+            // error = "Failed to load data";
+        }, 1000);
+    }
+
+    // Initial data load
+    refreshData();
+</script>
+
+<div class="container max-w-7xl mx-auto px-4 py-8">
+    <div class="flex flex-col space-y-6">
+        <!-- Dashboard Summary KPIs -->
+        {#if !loading && !error && filteredStartups.length > 0}
+            <div
+                class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-2 fade-in"
+            >
+                <div
+                    class="bg-card border rounded-lg shadow-sm p-4 flex items-center justify-between"
+                >
+                    <div>
+                        <h3 class="text-sm font-medium text-muted-foreground">
+                            Total Startups
+                        </h3>
+                        <p class="text-2xl font-bold mt-1">{startups.length}</p>
+                        <p class="text-xs text-muted-foreground mt-1">
+                            {filterOptions.industry !== "all" ||
+                            filterOptions.stage !== "all" ||
+                            filterOptions.search
+                                ? `${filteredStartups.length} matching filters`
+                                : `Across ${new Set(startups.map((s) => s.industry)).size} industries`}
+                        </p>
+                    </div>
+                    <div class="bg-primary/10 p-3 rounded-full text-primary">
+                        <Rocket class="h-6 w-6" />
+                    </div>
+                </div>
+
+                <div
+                    class="bg-card border rounded-lg shadow-sm p-4 flex items-center justify-between"
+                >
+                    <div>
+                        <h3 class="text-sm font-medium text-muted-foreground">
+                            Total Funding
+                        </h3>
+                        <p class="text-2xl font-bold mt-1">
+                            {formatCurrency(
+                                startups.reduce(
+                                    (total, s) => total + s.fundingRaised,
+                                    0,
+                                ),
+                            )}
+                        </p>
+                        <p class="text-xs text-muted-foreground mt-1">
+                            {Math.round(
+                                startups.reduce(
+                                    (acc, s) => acc + (s.fundingProgress || 0),
+                                    0,
+                                ) / startups.length,
+                            )}% of total goal
+                        </p>
+                    </div>
+                    <div
+                        class="bg-green-100 dark:bg-green-900/30 p-3 rounded-full text-green-600 dark:text-green-400"
+                    >
+                        <DollarSign class="h-6 w-6" />
+                    </div>
+                </div>
+
+                <div
+                    class="bg-card border rounded-lg shadow-sm p-4 flex items-center justify-between"
+                >
+                    <div>
+                        <h3 class="text-sm font-medium text-muted-foreground">
+                            Team Members
+                        </h3>
+                        <p class="text-2xl font-bold mt-1">
+                            {startups.reduce((total, s) => total + s.team, 0)}
+                        </p>
+                        <p class="text-xs text-muted-foreground mt-1">
+                            Avg. {Math.round(
+                                startups.reduce((acc, s) => acc + s.team, 0) /
+                                    startups.length,
+                            )} per startup
+                        </p>
+                    </div>
+                    <div
+                        class="bg-blue-100 dark:bg-blue-900/30 p-3 rounded-full text-blue-600 dark:text-blue-400"
+                    >
+                        <Users class="h-6 w-6" />
+                    </div>
+                </div>
+
+                <div
+                    class="bg-card border rounded-lg shadow-sm p-4 flex items-center justify-between"
+                >
+                    <div>
+                        <h3 class="text-sm font-medium text-muted-foreground">
+                            Performance
+                        </h3>
+                        <p class="text-2xl font-bold mt-1">
+                            {startups.some(
+                                (s) => s.metrics?.growth !== undefined,
+                            )
+                                ? `+${Math.round(startups.reduce((acc, s) => acc + (s.metrics?.growth || 0), 0) / startups.filter((s) => s.metrics?.growth !== undefined).length)}%`
+                                : "N/A"}
+                        </p>
+                        <p class="text-xs text-muted-foreground mt-1">
+                            Avg. growth rate
+                        </p>
+                    </div>
+                    <div
+                        class="bg-amber-100 dark:bg-amber-900/30 p-3 rounded-full text-amber-600 dark:text-amber-400"
+                    >
+                        <TrendingUp class="h-6 w-6" />
+                    </div>
+                </div>
+            </div>
+
+            <!-- Actions & Insights Section -->
+            <div class="flex flex-col lg:flex-row gap-4 fade-in">
+                <!-- Pending Tasks Alert -->
+                {#if startups.some(s => s.tasks?.some((t: {completed: boolean}) => !t.completed))}
+                    <div
+                        class="bg-muted/50 border rounded-lg p-4 flex-1 flex items-start gap-3"
+                    >
+                        <div class="text-amber-500 mt-0.5">
+                            <AlertTriangle class="h-5 w-5" />
+                        </div>
+                        <div class="flex-1">
+                            <h3 class="font-medium text-sm">Pending Tasks</h3>
+                            <p class="text-sm text-muted-foreground mt-0.5">
+                                You have {startups.reduce(
+                                    (acc, s) =>
+                                        acc +
+                                        (s.tasks?.filter((t: {completed: boolean}) => !t.completed)
+                                            .length || 0),
+                                    0,
+                                )} pending tasks across your startups
+                            </p>
+                            <div class="mt-2 space-x-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    class="text-xs h-8"
+                                >
+                                    View All Tasks
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                {/if}
+
+                <!-- Loading Skeleton for summary section -->
+                {#if loading}
+                    <div
+                        class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-2 fade-in"
+                    >
+                        {#each Array(4) as _}
+                            <div
+                                class="bg-card border rounded-lg shadow-sm p-4 flex items-center justify-between"
+                            >
+                                <div>
+                                    <Skeleton.Root class="h-4 w-24 mb-2" />
+                                    <Skeleton.Root class="h-8 w-16 mb-2" />
+                                    <Skeleton.Root class="h-3 w-28" />
+                                </div>
+                                <Skeleton.Root class="h-12 w-12 rounded-full" />
+                            </div>
+                        {/each}
+                    </div>
+                {/if}
+
+                <!-- Insights Card -->
+                <div
+                    class="bg-primary/5 border-primary/20 border rounded-lg p-4 flex-1"
+                >
+                    <div class="flex items-center gap-2 mb-2">
+                        <Sparkles class="h-5 w-5 text-primary" />
+                        <h3 class="font-medium">Insights & Recommendations</h3>
+                    </div>
+                    <div class="space-y-2">
+                        {#if startups.some((s) => s.fundingProgress && s.fundingProgress < 30)}
+                            <p class="text-sm text-muted-foreground">
+                                <span class="font-medium text-foreground"
+                                    >Funding Alert:</span
+                                > Some of your startups are below 30% of their funding
+                                goal. Consider revisiting your pitch deck or expanding
+                                investor outreach.
+                            </p>
+                        {/if}
+                        {#if startups.some((s) => s.team < 5 && (s.stage === "seed" || s.stage === "series_a"))}
+                            <p class="text-sm text-muted-foreground">
+                                <span class="font-medium text-foreground"
+                                    >Team Growth:</span
+                                >
+                                Consider expanding your team to support scaling
+                                in the {startups.find(
+                                    (s) =>
+                                        s.team < 5 &&
+                                        (s.stage === "seed" ||
+                                            s.stage === "series_a"),
+                                )?.name} startup.
+                            </p>
+                        {/if}
+                        <p class="text-sm text-muted-foreground">
+                            <span class="font-medium text-foreground"
+                                >Growth Opportunity:</span
+                            >
+                            Your highest performing startup is showing {Math.max(
+                                ...startups
+                                    .filter((s) => s.metrics?.growth)
+                                    .map((s) => s.metrics?.growth || 0),
+                            )}% growth. Consider allocating more resources here.
+                        </p>
+                    </div>
+                </div>
+
+                <!-- Quick Actions Card -->
+                <div class="bg-card border rounded-lg p-4 lg:w-72">
+                    <h3 class="font-medium mb-3 flex items-center gap-2">
+                        <Rocket class="h-4 w-4 text-primary" />
+                        Quick Actions
+                    </h3>
+                    <div class="space-y-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            class="w-full justify-start text-left"
+                            onclick={() =>
+                                (window.location.href =
+                                    "/dashboard/founder/startup/create")}
+                        >
+                            <Plus class="h-3.5 w-3.5 mr-2 flex-shrink-0" />
+                            <span>Add New Startup</span>
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            class="w-full justify-start text-left"
+                        >
+                            <FileEdit class="h-3.5 w-3.5 mr-2 flex-shrink-0" />
+                            <span>Update Metrics</span>
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            class="w-full justify-start text-left"
+                        >
+                            <Users class="h-3.5 w-3.5 mr-2 flex-shrink-0" />
+                            <span>Manage Team Members</span>
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        {/if}
+
+        <!-- Pagination (if needed in the future) -->
+        {#if !loading && !error && filteredStartups.length > 12}
+            <div class="flex justify-center mt-8">
+                <div class="flex items-center gap-2">
+                    <Button variant="outline" size="sm" disabled
+                        >Previous</Button
+                    >
+                    <span
+                        class="px-3 py-1 rounded-md bg-primary text-primary-foreground text-sm"
+                        >1</span
+                    >
+                    <Button variant="outline" size="sm">2</Button>
+                    <Button variant="outline" size="sm">3</Button>
+                    <Button variant="outline" size="sm">Next</Button>
+                </div>
+            </div>
+        {/if}
+
+        <!-- Header -->
+        <div class="flex justify-between items-center">
+            <h1 class="text-2xl font-bold">Your Startups</h1>
+            <div class="flex items-center space-x-4">
+                <Button
+                    variant="outline"
+                    class="hidden md:flex"
+                    onclick={() =>
+                        (viewMode = viewMode === "grid" ? "list" : "grid")}
+                >
+                    {#if viewMode === "grid"}
+                        <List class="w-5 h-5 mr-2" />
+                        List View
+                    {:else}
+                        <LayoutGrid class="w-5 h-5 mr-2" />
+                        Grid View
+                    {/if}
+                </Button>
+                <Button class="hidden md:flex">
+                    <a
+                        href="/dashboard/founder/startup/create"
+                        class="flex items-center"
+                    >
+                        <Plus class="size-5 mr-2" />
+                        Add Startup
+                    </a>
+                </Button>
+            </div>
+        </div>
+
+        <!-- Filters -->
+        <div class="flex flex-wrap gap-4">
+            <div class="relative">
+                <Input
+                    bind:value={filterOptions.search}
+                    placeholder="Search startups..."
+                    class="pl-10 max-w-3xl"
+                />
+                <Search
+                    class="size-5 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2"
+                />
+            </div>
+
+            <Select.Root type="single" bind:value={filterOptions.industry}>
+                <Select.Trigger class="w-full md:w-40">
+                    <span
+                        >{industryOptions.find(
+                            (i) => i.value === filterOptions.industry,
+                        )?.label || "Industry"}</span
+                    >
+                </Select.Trigger>
+                <Select.Content>
+                    <Select.Group>
+                        <Select.GroupHeading>Industries</Select.GroupHeading>
+                        {#each industryOptions as option}
+                            <Select.Item value={option.value}
+                                >{option.label}</Select.Item
+                            >
+                        {/each}
+                    </Select.Group>
+                </Select.Content>
+            </Select.Root>
+
+            <Select.Root type="single" bind:value={filterOptions.stage}>
+                <Select.Trigger class="w-full md:w-40">
+                    <span
+                        >{stageOptions.find(
+                            (s) => s.value === filterOptions.stage,
+                        )?.label || "Stage"}</span
+                    >
+                </Select.Trigger>
+                <Select.Content>
+                    <Select.Group>
+                        <Select.GroupHeading>Stages</Select.GroupHeading>
+                        {#each stageOptions as option}
+                            <Select.Item value={option.value}>
+                                {option.label}
+                            </Select.Item>
+                        {/each}
+                    </Select.Group>
+                </Select.Content>
+            </Select.Root>
+
+            <Select.Root type="single" bind:value={filterOptions.sortBy}>
+                <Select.Trigger class="w-full md:w-40">
+                    <span
+                        >{sortOptions.find(
+                            (s) => s.value === filterOptions.sortBy,
+                        )?.label || "Sort by"}</span
+                    >
+                </Select.Trigger>
+                <Select.Content>
+                    <Select.Group>
+                        <Select.GroupHeading>Sort Options</Select.GroupHeading>
+                        {#each sortOptions as option}
+                            <Select.Item value={option.value}>
+                                {option.label}
+                            </Select.Item>
+                        {/each}
+                    </Select.Group>
+                </Select.Content>
+            </Select.Root>
+        </div>
+
+        <!-- Loading State -->
+        {#if loading}
+            <div class="animate-in fade-in-0 slide-in-from-top-5 duration-500">
+                {#if viewMode === "grid"}
+                    <div
+                        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+                    >
+                        {#each Array(6) as _, i}
+                            <div class="border rounded-lg p-6 space-y-4">
+                                <div class="flex items-center gap-4">
+                                    <Skeleton.Root
+                                        class="h-16 w-16 rounded-lg"
+                                    />
+                                    <div class="space-y-2">
+                                        <Skeleton.Root class="h-5 w-40" />
+                                        <Skeleton.Root class="h-4 w-24" />
+                                    </div>
+                                </div>
+                                <Skeleton.Root class="h-20 w-full" />
+                                <div class="flex justify-between items-center">
+                                    <div class="flex items-center gap-2">
+                                        <DollarSign
+                                            class="h-4 w-4 text-muted-foreground"
+                                        />
+                                        <Skeleton.Root class="h-4 w-20" />
+                                    </div>
+                                    <div class="flex items-center gap-2">
+                                        <Users
+                                            class="h-4 w-4 text-muted-foreground"
+                                        />
+                                        <Skeleton.Root class="h-4 w-12" />
+                                    </div>
+                                </div>
+                            </div>
+                        {/each}
+                    </div>
+                {:else}
+                    <div class="space-y-4">
+                        {#each Array(6) as _, i}
+                            <div
+                                class="border rounded-lg p-4 flex items-center justify-between"
+                            >
+                                <div class="flex items-center gap-4">
+                                    <Skeleton.Root
+                                        class="h-12 w-12 rounded-lg"
+                                    />
+                                    <div class="space-y-2">
+                                        <Skeleton.Root class="h-5 w-40" />
+                                        <Skeleton.Root class="h-4 w-60" />
+                                    </div>
+                                </div>
+                                <Skeleton.Root class="h-8 w-24" />
+                            </div>
+                        {/each}
+                    </div>
+                {/if}
+            </div>
+            <!-- Error State -->
+        {:else if error}
+            <div
+                class="flex flex-col items-center justify-center py-16 border border-dashed rounded-lg animate-in fade-in slide-in-from-bottom-10 duration-500"
+            >
+                <div
+                    class="bg-destructive/10 p-3 rounded-full mb-4 text-destructive"
+                >
+                    <AlertCircle class="w-10 h-10" />
+                </div>
+                <h3 class="text-xl font-semibold mb-2">
+                    Unable to Load Startups
+                </h3>
+                <p class="text-muted-foreground text-center max-w-md mb-6">
+                    We encountered a problem while loading your startup data.
+                    This might be due to a network issue or a server problem.
+                </p>
+                <Button onclick={refreshData} class="gap-2">
+                    <RotateCw class="w-4 h-4" />
+                    Try Again
+                </Button>
+            </div>
+            <!-- Empty State -->
+        {:else if filteredStartups.length === 0}
+            <div
+                class="flex flex-col items-center justify-center py-16 border border-dashed rounded-lg animate-in fade-in slide-in-from-bottom-10 duration-500"
+            >
+                <div
+                    class="bg-muted p-3 rounded-full mb-4 text-muted-foreground"
+                >
+                    <FolderOpen class="w-10 h-10" />
+                </div>
+                <h3 class="text-xl font-semibold mb-2">No startups found</h3>
+                <p class="text-muted-foreground text-center max-w-md mb-6">
+                    {#if filterOptions.search || filterOptions.industry !== "all" || filterOptions.stage !== "all"}
+                        We couldn't find any startups matching your current
+                        filters. Try adjusting your criteria or clear filters.
+                    {:else}
+                        You haven't added any startups to your portfolio yet.
+                        Create your first startup to begin tracking your
+                        progress.
+                    {/if}
+                </p>
+                <div class="flex flex-wrap gap-3 justify-center">
+                    {#if filterOptions.search || filterOptions.industry !== "all" || filterOptions.stage !== "all"}
+                        <Button
+                            variant="outline"
+                            onclick={() => {
+                                filterOptions.search = "";
+                                filterOptions.industry = "all";
+                                filterOptions.stage = "all";
+                                filterOptions.sortBy = "newest";
+                            }}
+                        >
+                            <RotateCw class="h-3.5 w-3.5 mr-2" />
+                            Clear Filters
+                        </Button>
+                    {/if}
+                    <Button
+                        class={!filterOptions.search &&
+                        filterOptions.industry === "all" &&
+                        filterOptions.stage === "all"
+                            ? "animate-pulse"
+                            : ""}
+                    >
+                        <a
+                            href="/dashboard/founder/startup/create"
+                            class="flex items-center gap-2"
+                        >
+                            <Plus class="w-4 h-4" />
+                            Add {filterOptions.search ||
+                            filterOptions.industry !== "all" ||
+                            filterOptions.stage !== "all"
+                                ? "New"
+                                : "Your First"} Startup
+                        </a>
+                    </Button>
+                </div>
+            </div>
+            <!-- Startup Grid/List -->
+        {:else if viewMode === "grid"}
+            <div
+                class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 fade-in animate-in slide-in-from-bottom-8 duration-500 stagger-[100ms]"
+            >
+                {#each filteredStartups as startup (startup.id)}
+                    <div class="card-hover">
+                        <StartupCard {startup} />
+                    </div>
+                {/each}
+            </div>
+        {:else}
+            <div
+                class="flex flex-col space-y-4 fade-in animate-in slide-in-from-bottom-5 duration-500 stagger-[75ms]"
+            >
+                {#each filteredStartups as startup (startup.id)}
+                    <div class="card-hover">
+                        <StartupList {startup} />
+                    </div>
+                {/each}
+            </div>
+        {/if}
+    </div>
+</div>
+
+<style>
+    /* Animation classes */
+    .fade-in {
+        animation: fadeIn 0.3s ease-in-out;
+    }
+
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+            transform: translateY(10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    /* Ensure these styles apply to all instances */
+    :global(.hide-scrollbar::-webkit-scrollbar) {
+        display: none;
+    }
+
+    :global(.hide-scrollbar) {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+
+    /* Hover effects - apply globally */
+    :global(.card-hover) {
+        transition: all 0.2s ease-in-out;
+    }
+
+    :global(.card-hover:hover) {
+        transform: translateY(-2px);
+        box-shadow:
+            0 10px 15px -3px rgba(0, 0, 0, 0.1),
+            0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    }
+</style>

--- a/frontend-sv/src/routes/dashboard/founder/startup/README.md
+++ b/frontend-sv/src/routes/dashboard/founder/startup/README.md
@@ -1,0 +1,60 @@
+# Founder Dashboard
+
+A modern, responsive dashboard for startup founders to manage and track their ventures. This dashboard provides an intuitive interface for monitoring key metrics, managing startup information, and accessing important insights.
+
+## Features
+
+### Overview
+
+- **At-a-glance KPIs**: Total startups, funding raised, team size, and performance metrics
+- **Actions & Insights**: Contextual recommendations based on your startup data
+- **Quick Actions**: Common tasks accessible from the dashboard homepage
+- **Tasks Tracking**: View pending tasks across all your startups
+
+### Startup Management
+
+- **Dual View Modes**: Toggle between grid and list views
+- **Advanced Filtering**: Filter startups by industry, stage, and other criteria
+- **Sorting Options**: Sort by newest, funding amount, name, and more
+- **Search**: Quickly find startups by name or description
+
+### UI/UX Design
+
+- **Responsive Design**: Optimized for all device sizes
+- **Skeleton Loading**: Provides visual feedback during data fetch
+- **Smooth Animations**: Enhances user experience with subtle transitions
+- **Empty State Handling**: Clear guidance when no startups are found
+- **Error Recovery**: User-friendly error states with recovery options
+
+## Components
+
+The dashboard is built with modular components:
+
+- `StartupCard.svelte`: Grid view display of startup information
+- `StartupList.svelte`: List view display of startup information
+- `+page.svelte`: Main dashboard layout and logic
+
+## Usage
+
+The dashboard automatically loads startup data and provides an intuitive interface for managing your ventures. Use the filters and search functionality to quickly find specific startups, and toggle between grid and list views based on your preference.
+
+### Actions
+
+- **Add Startup**: Create a new startup entry
+- **View Details**: Access detailed information about a specific startup
+- **Edit Startup**: Update startup information
+- **Manage Tasks**: Track and update task status
+
+## Technical Details
+
+- Built with Svelte 5 and TypeScript
+- Uses ShadCn UI components
+- Implements modern Svelte patterns (runes, state management)
+- Reactive updates for real-time filtering and sorting
+
+## Future Enhancements
+
+- Integration with analytics for deeper insights
+- Advanced team management features
+- Funding progress tracking with milestones
+- Investor relationship management

--- a/frontend-sv/src/routes/dashboard/founder/startup/create/+page.server.ts
+++ b/frontend-sv/src/routes/dashboard/founder/startup/create/+page.server.ts
@@ -1,0 +1,57 @@
+import { startupSchema } from '$lib/schemas/startup-schema';
+import { fail } from '@sveltejs/kit';
+import { zod } from 'sveltekit-superforms/adapters';
+import { superValidate } from 'sveltekit-superforms/server';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  return {
+    form: await superValidate(zod(startupSchema)),
+  };
+};
+
+export const actions: Actions = {
+  default: async (event) => {
+    const form = await superValidate(event, zod(startupSchema));
+    
+    if (!form.valid) {
+      return fail(400, { form });
+    }
+    
+    try {
+      // Here you would process form data and handle file uploads
+      // This would connect to your backend API or database
+      
+      // Example API call (replace with your actual endpoint)
+      /*
+      const response = await fetch('/api/create-new-startup', {
+        method: 'POST',
+        body: JSON.stringify(form.data),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      
+      if (!response.ok) {
+        throw new Error('Failed to create startup');
+      }
+      */
+      
+      // Return the form with a success message
+      return {
+        form,
+        success: true,
+        message: 'Startup created successfully'
+      };
+    } catch (error) {
+      console.error('Error creating startup:', error);
+      
+      // Return the form with error message
+      return fail(500, {
+        form,
+        success: false,
+        message: error instanceof Error ? error.message : 'An unexpected error occurred'
+      });
+    }
+  }
+};

--- a/frontend-sv/src/routes/dashboard/founder/startup/create/+page.svelte
+++ b/frontend-sv/src/routes/dashboard/founder/startup/create/+page.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+    import NewStartupForm from "@/components/NewStartupForm.svelte";
+    import NewStartupPreview from "@/components/NewStartupPreview.svelte";
+    import { Button } from "@/components/ui/button";
+    import { startupSchema } from "@/schemas/startup-schema";
+    import { cn } from "@/utils";
+    import { toast } from "svelte-sonner";
+    import { zodClient } from "sveltekit-superforms/adapters";
+    import { superForm } from "sveltekit-superforms/client";
+    import type { PageData } from "./$types";
+
+    let { data }: { data: PageData } = $props();
+
+    // Use superForm to manage the form state
+    const form = superForm(data.form, {
+        dataType: "json",
+        validators: zodClient(startupSchema),
+        onUpdate({ form }) {
+            if (form.valid) {
+                toast.success("Startup profile saved");
+            }
+        },
+        onError(result) {
+            toast.error("Failed to save startup profile", {
+                description: "Please check the form for errors",
+            });
+        },
+    });
+
+    const {
+        form: formData,
+        errors,
+        enhance,
+        delayed,
+        message,
+        submitting,
+    } = form;
+
+    // State with Svelte 5 runes
+    let showPreview = $state(true);
+    let showTeamSection = $state(false);
+
+    // File handling with runes
+    let pitchDeckFile = $state<File | null>(null);
+    let logoFile = $state<File | null>(null);
+    let logoPreview = $state<string | null>(null);
+    let productScreenshots = $state<File[]>([]);
+    let demoVideo = $state<File | null>(null);
+    let screenshotPreviews = $state<string[]>([]);
+
+    // Handlers for file uploads
+    function handleFileUpload(event: { detail: { files: File[] } }) {
+        if (event.detail.files.length > 0) {
+            pitchDeckFile = event.detail.files[0];
+        }
+    }
+
+    function handleFileRemove() {
+        pitchDeckFile = null;
+    }
+
+    function handleLogoUpload(event: { detail: { files: File[] } }) {
+        if (event.detail.files.length > 0) {
+            logoFile = event.detail.files[0];
+            logoPreview = URL.createObjectURL(event.detail.files[0]);
+        }
+    }
+
+    function handleLogoRemove() {
+        logoFile = null;
+        if (logoPreview) {
+            URL.revokeObjectURL(logoPreview);
+            logoPreview = null;
+        }
+    }
+
+    function handleScreenshotUpload(event: { detail: { files: File[] } }) {
+        productScreenshots = event.detail.files;
+        screenshotPreviews = event.detail.files.map((file) =>
+            URL.createObjectURL(file),
+        );
+    }
+
+    function handleScreenshotRemove(index: number) {
+        URL.revokeObjectURL(screenshotPreviews[index]);
+        productScreenshots = productScreenshots.filter((_, i) => i !== index);
+        screenshotPreviews = screenshotPreviews.filter((_, i) => i !== index);
+    }
+
+    function handleDemoVideoUpload(event: { detail: { files: File[] } }) {
+        if (event.detail.files.length > 0) {
+            demoVideo = event.detail.files[0];
+        }
+    }
+
+    function handleDemoVideoRemove() {
+        demoVideo = null;
+    }
+
+    // Team members
+    function addTeamMember() {
+        const currentTeamMembers = $formData.teamMembers || [];
+        $formData.teamMembers = [
+            ...currentTeamMembers,
+            {
+                name: "",
+                role: "",
+                bio: "",
+                linkedin: "",
+            },
+        ];
+    }
+
+    function removeTeamMember(index: number) {
+        const currentTeamMembers = $formData.teamMembers || [];
+        $formData.teamMembers = currentTeamMembers.filter(
+            (_, i) => i !== index,
+        );
+    }
+
+    // Timeline milestones
+    function addPastMilestone() {
+        const timeline = $formData.timeline || { past: [], future: [] };
+        const currentPast = timeline.past || [];
+
+        $formData.timeline = {
+            ...timeline,
+            past: [
+                ...currentPast,
+                {
+                    date: "",
+                    title: "",
+                    description: "",
+                    type: "achievement" as const,
+                },
+            ],
+        };
+    }
+
+    function removePastMilestone(index: number) {
+        if (!$formData.timeline?.past) return;
+
+        $formData.timeline = {
+            ...$formData.timeline,
+            past: $formData.timeline.past.filter((_, i) => i !== index),
+        };
+    }
+
+    function addFutureMilestone() {
+        const timeline = $formData.timeline || { past: [], future: [] };
+        const currentFuture = timeline.future || [];
+
+        $formData.timeline = {
+            ...timeline,
+            future: [
+                ...currentFuture,
+                {
+                    date: "",
+                    title: "",
+                    description: "",
+                    type: "launch" as const,
+                },
+            ],
+        };
+    }
+
+    function removeFutureMilestone(index: number) {
+        if (!$formData.timeline?.future) return;
+
+        $formData.timeline = {
+            ...$formData.timeline,
+            future: $formData.timeline.future.filter((_, i) => i !== index),
+        };
+    }
+
+    // Toggle functions
+    function togglePreview() {
+        showPreview = !showPreview;
+    }
+
+    function toggleTeamSection() {
+        showTeamSection = !showTeamSection;
+    }
+</script>
+
+<div class="container mx-auto py-8">
+    <div class="mx-auto">
+        <div class="flex flex-col gap-8">
+            <div class="flex justify-between items-center">
+                <div>
+                    <h1 class="text-3xl font-bold mb-2">Create New Startup</h1>
+                    <p class="text-muted-foreground">
+                        Fill in your startup details to create your profile
+                    </p>
+                </div>
+                <Button variant="outline" onclick={() => togglePreview()}>
+                    {showPreview ? "Hide Preview" : "Show Preview"}
+                </Button>
+            </div>
+
+            <div
+                class={cn(
+                    "grid grid-cols-1 lg:grid-cols-2 gap-8",
+                    !showPreview && "!grid-cols-1"
+                )}
+                
+            >
+                <!-- Form Section -->
+                <NewStartupForm {data} />
+
+                <!-- Preview Section -->
+                <NewStartupPreview {showPreview} {data} />
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### TL;DR

Added UI components for the startup dashboard including sidebar navigation, startup cards, and list views.

### What changed?

- Created reusable UI components for the dashboard interface:
  - `StartupCard.svelte` and `StartupList.svelte` for displaying startup information in different formats
  - Sidebar navigation components including `app-sidebar.svelte`, `nav-main.svelte`, `nav-projects.svelte`, and `nav-user.svelte`
  - UI utility components like breadcrumbs, collapsible sections, and tooltips
- Implemented the dashboard layout with a responsive sidebar
- Added startup listing page with grid/list view toggle and filtering options
- Updated the founder dashboard with metrics and activity displays

### How to test?

1. Navigate to `/dashboard/founder` to see the main dashboard with metrics
2. Visit `/dashboard/founder/startup` to view the startup listing page
3. Test the sidebar navigation by clicking on different menu items
4. Try toggling between grid and list views on the startup page
5. Test the filtering and search functionality on the startup listing page

### Why make this change?

This change establishes the core UI components needed for the startup dashboard, providing founders with a way to manage their startups and view important metrics. The components are designed to be reusable across the application and follow a consistent design language. The sidebar navigation improves user experience by providing easy access to different sections of the dashboard.