### PR TITLE
(feat): action to deploy to cloud

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -29,14 +29,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/auth@v2
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
           service_account: ${{ secrets.SA_EMAIL }}
           workload_identity_provider: ${{ secrets.WIF_PROVIDER_FULL_PATH }}
 
       - name: Configure Docker to use Artifact Registry
-        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev
+        run: gcloud --quiet auth configure-docker "${{ vars.GCP_AR_REPO_URL }}"
 
       - name: Build and push Docker image to Artifact Registry
         run: |


### PR DESCRIPTION
### TL;DR

Updated Google Cloud authentication in GitHub Actions workflow for Cloud Run deployment.

### What changed?

- Replaced `google-github-actions/setup-gcloud@v2` with `google-github-actions/auth@v2` for Google Cloud authentication
- Modified Docker configuration command to use the `${{ vars.GCP_AR_REPO_URL }}` variable instead of constructing the URL from region
- Added `--quiet` flag to the `gcloud auth configure-docker` command to suppress prompts

### How to test?

1. Trigger the GitHub Actions workflow for Cloud Run deployment
2. Verify that the authentication step completes successfully
3. Confirm that Docker is properly configured to use the Artifact Registry
4. Ensure the build and push steps complete without errors

### Why make this change?

The `google-github-actions/auth@v2` action is the recommended approach for authenticating with Google Cloud in GitHub Actions, providing better security and more features than the older setup-gcloud action. Using the repository URL variable directly also simplifies configuration and makes the workflow more maintainable.